### PR TITLE
ai: add playwriter skill + fix linear hash

### DIFF
--- a/flake.lock
+++ b/flake.lock
@@ -484,6 +484,22 @@
         "type": "github"
       }
     },
+    "playwriter-skills": {
+      "flake": false,
+      "locked": {
+        "lastModified": 1777029091,
+        "narHash": "sha256-op5OPm2hesCwjT1kwhy6dbrkA+JJPb6C3leWvKrNKbQ=",
+        "owner": "remorses",
+        "repo": "playwriter",
+        "rev": "e9918fcadc2462576dc0afb5942d77317d8b593d",
+        "type": "github"
+      },
+      "original": {
+        "owner": "remorses",
+        "repo": "playwriter",
+        "type": "github"
+      }
+    },
     "pup-skills": {
       "flake": false,
       "locked": {
@@ -518,6 +534,7 @@
         "linear-cli-skills": "linear-cli-skills",
         "llm-agents": "llm-agents",
         "nixpkgs": "nixpkgs_3",
+        "playwriter-skills": "playwriter-skills",
         "pup-skills": "pup-skills",
         "superpowers": "superpowers",
         "vercel-skills-cli": "vercel-skills-cli",

--- a/flake.nix
+++ b/flake.nix
@@ -55,6 +55,11 @@
       flake = false;
     };
 
+    playwriter-skills = {
+      url = "github:remorses/playwriter";
+      flake = false;
+    };
+
     wshobson-agents = {
       url = "github:wshobson/agents";
       flake = false;

--- a/modules/ai/instructions/INSTRUCTIONS.md
+++ b/modules/ai/instructions/INSTRUCTIONS.md
@@ -14,9 +14,15 @@ Use **Exa** (MCP server) first — higher quality, focused results. Fall back to
 
 </important>
 
-<important if="you are asked to load a website, visit a URL, fill a form, or interact with a web page">
+<important if="I ask you to look at a tab, browser tab, or any of my open tabs">
 
-Use the **agent-browser** skill. Only use Chrome DevTools MCP when the user explicitly asks for DevTools, debugging, performance analysis, or network inspection.
+Use the **playwriter** skill. Playwriter connects to my running Chrome via a browser extension, so my logins, cookies, and extensions are already there — unlike agent-browser which spawns a fresh browser.
+
+</important>
+
+<important if="you are asked to load a website, visit a URL, fill a form, or interact with a web page (and it is NOT one of my already-open browser tabs)">
+
+Use the **agent-browser** skill. Only use Chrome DevTools MCP when I explicitly ask for DevTools, debugging, performance analysis, or network inspection. If I am referring to a tab in my running Chrome, use the **playwriter** skill instead.
 
 </important>
 

--- a/modules/ai/skills/default.nix
+++ b/modules/ai/skills/default.nix
@@ -24,6 +24,10 @@
         input = "agent-browser-skills";
         subdir = "skills";
       };
+      playwriter = {
+        input = "playwriter-skills";
+        subdir = "skills";
+      };
       wshobson-agents = {
         input = "wshobson-agents";
         subdir = "plugins/javascript-typescript/skills";
@@ -50,6 +54,7 @@
       "find-skills"
       "find-docs"
       "agent-browser"
+      "playwriter"
       "typescript-advanced-types"
       "vitest"
       "itechmeat/react-testing-library"

--- a/modules/home-manager/packages/linear/default.nix
+++ b/modules/home-manager/packages/linear/default.nix
@@ -11,7 +11,7 @@ let
 
     src = pkgs.fetchurl {
       url = "https://github.com/schpet/linear-cli/releases/download/v${version}/linear-aarch64-apple-darwin.tar.xz";
-      hash = "";
+      hash = "sha256-Eh/h7ubZCyLnbk6Yy7YkR07s2XCkpMYi/U1QiJtX2sw=";
     };
 
     sourceRoot = "linear-aarch64-apple-darwin";


### PR DESCRIPTION
## Summary

Two changes:

1. **Add [`remorses/playwriter`](https://github.com/remorses/playwriter)** — a Chrome-extension-based agent skill that controls **my actual running Chrome** (with existing logins, cookies, and extensions) rather than spawning a fresh ephemeral browser the way `agent-browser` does.
2. **Fix `linear-cli` hash** — same pre-existing breakage as the `pup` fix in #103: commit 54dd23f (#104, automated dependency update) bumped linear to v2.0.0 but left an empty hash. Only surfaces on the work host (`Castula-KQPN`) since `linear` isn't on personal. Without this, `darwin-rebuild switch` fails on the work mac.

## Changes

### Playwriter skill
- **`flake.nix`** — new `playwriter-skills` input pinned to `github:remorses/playwriter`
- **`flake.lock`** — locked to rev `e9918fc` (2026-04-24)
- **`modules/ai/skills/default.nix`** — new `playwriter` source (`subdir = "skills"`) and `"playwriter"` added to `skills.enable`
- **`modules/ai/instructions/INSTRUCTIONS.md`**:
  - New rule: any reference to a "tab" / "browser tab" / "my open tabs" → use **playwriter**
  - Existing `agent-browser` rule tightened to defer to playwriter for already-open tabs, removing routing ambiguity

### Linear hash fix
- **`modules/home-manager/packages/linear/default.nix`** — `hash = ""` → `sha256-Eh/h7ubZCyLnbk6Yy7YkR07s2XCkpMYi/U1QiJtX2sw=` for the v2.0.0 darwin-arm64 tarball

## Why two browser-automation skills?

| Skill | Purpose |
|---|---|
| `agent-browser` | Spin up an ephemeral browser, automate from scratch |
| `playwriter` *(new)* | Attach to my actual Chrome — tabs I already opened, sites I'm logged into |
| `chrome-devtools` | DevTools-style debugging, perf, network inspection (already explicit override) |

## Verification

- `nix flake check --no-build` — passed
- `treefmt --fail-on-change` — clean
- `statix check` — clean
- `lsp_diagnostics` — 0 errors across changed files
- Pre-commit hooks (deadnix, flake-check, statix, treefmt) — all passed both commits
- `nix-build` of the `linear-aarch64-apple-darwin.tar.xz` fetchurl with the new hash succeeded (real hash matches what darwin-rebuild reported)
- Confirmed `skills/playwriter/SKILL.md` exists in the upstream playwriter repo

## Runtime prerequisites for playwriter (out of scope for this PR)

After applying:

1. Install the [Playwriter Chrome extension](https://chromewebstore.google.com/detail/playwriter-mcp/jfeammnjpkecdekppnclgkkffahnhfhe)
2. Click the extension icon on a tab → green = connected
3. Install the CLI globally: `npm i -g playwriter`