### PR TITLE
opencode: force home.file symlink for oh-my-openagent.json

### DIFF
--- a/modules/ai/harnesses/opencode/personal.nix
+++ b/modules/ai/harnesses/opencode/personal.nix
@@ -26,7 +26,14 @@ let
   };
 in
 {
-  home.file.".config/opencode/oh-my-openagent.json".text = builtins.toJSON config;
+  # force = true so home-manager re-establishes its symlink even after the
+  # opencode plugin atomically rewrites the file in place (renameSync), which
+  # would otherwise leave a stale user-owned regular file with drifted values
+  # (notably git_master.include_co_authored_by) at this path.
+  home.file.".config/opencode/oh-my-openagent.json" = {
+    force = true;
+    text = builtins.toJSON config;
+  };
 
   programs.opencode.settings.plugin = [
     "opencode-with-claude"

--- a/modules/ai/harnesses/opencode/work.nix
+++ b/modules/ai/harnesses/opencode/work.nix
@@ -72,7 +72,14 @@ let
   };
 in
 {
-  home.file.".config/opencode/oh-my-openagent.json".text = builtins.toJSON config;
+  # force = true so home-manager re-establishes its symlink even after the
+  # opencode plugin atomically rewrites the file in place (renameSync), which
+  # would otherwise leave a stale user-owned regular file with drifted values
+  # (notably git_master.include_co_authored_by) at this path.
+  home.file.".config/opencode/oh-my-openagent.json" = {
+    force = true;
+    text = builtins.toJSON config;
+  };
 
   programs.zsh.initContent = ''
     export ANTHROPIC_API_KEY="$(cat /run/agenix/anthropic-api-key)"


### PR DESCRIPTION
## Summary

Fix config drift that was causing GitHub commits to show a `Co-authored-by: Sisyphus <clio-agent@sisyphuslabs.ai>` trailer (rendered as the `sisyphus-dev-ai` avatar) on commits made via opencode — even though `git_master.commit_footer` and `git_master.include_co_authored_by` are both `false` in the nix source.

## Root cause

The `oh-my-openagent` plugin migrates its config file at runtime using `writeFileAtomically` (`renameSync` under the hood). This breaks home-manager's symlink at `~/.config/opencode/oh-my-openagent.json` and replaces it with a user-owned regular file. Once the symlink is gone, subsequent `switch` runs do not restore it (home-manager's default behavior is to back up conflicts, not clobber). The result: the live file can drift to defaults — and when defaults are read by the `git-master` skill loader, the agent gets prompted with both attribution flags set to `true`.

## Fix

Set `home.file."config/opencode/oh-my-openagent.json".force = true` in both `personal.nix` and `work.nix`. This invokes home-manager's documented "silently delete the target regardless of whether it is a file or link" behavior on every activation, restoring the nix-managed symlink.

## Why not also `rm -f` in `entryBefore [ "writeBoundary" ]`?

Considered and rejected after consulting Oracle. Home-manager's activation docs explicitly require file deletion to run **after** `writeBoundary` — pre-write `rm` introduces a failure mode where activation aborts mid-flight and leaves the user with neither the symlink nor the original file. `force = true` already covers the regular-file case via the documented mechanism.

## Test plan

- [x] `nix flake check --no-build` passes
- [x] Both `darwinConfigurations` evaluate; rendered output confirms `force=true` and `"include_co_authored_by":false`
- [x] `treefmt`, `statix`, `deadnix`, `flake-check` pre-commit hooks pass
- [ ] Run `switch` on personal host
- [ ] Run `switch` on work host
- [ ] Post-switch: `readlink ~/.config/opencode/oh-my-openagent.json` returns a `/nix/store/…` path
- [ ] Test commit via opencode in another repo — no `Co-authored-by: Sisyphus` trailer

## Caveat

Even with this fix, the plugin will continue to replace the symlink with a regular file on opencode startup. The next `switch` always restores it. So you may transiently observe a regular file at the path between switches — its content will be correct (the migration only mutates `agents.*.model`), and `force = true` guarantees the next activation restores the symlink.