### PR TITLE
ai: add claude-mem opencode integration

### DIFF
--- a/modules/ai/harnesses/opencode/default.nix
+++ b/modules/ai/harnesses/opencode/default.nix
@@ -47,17 +47,39 @@ in
   # provides the matching session/tool capture plugin so opencode also
   # writes to the shared ~/.claude-mem/claude-mem.db that claude-code uses.
   #
-  # The installer copies a JS bundle from the npm package's prebuilt dist/
-  # to ~/.config/opencode/plugins/claude-mem.js. It also tries to inject a
-  # placeholder into ~/.config/opencode/AGENTS.md, which fails silently here
-  # because that path is owned by the instructions module — the plugin still
-  # captures sessions, but auto-injected memory context is not surfaced in
-  # AGENTS.md (query memory via the claude-mem MCP tools instead).
+  # The upstream `npx claude-mem install --ide opencode` always crashes near
+  # the end with EACCES when it tries to write ~/.claude/settings.json (which
+  # is a read-only nix symlink). The crash happens AFTER the marketplace dist
+  # bundle has already been copied to ~/.claude/plugins/marketplaces/thedotmack/dist/,
+  # so we let the installer do its bootstrap, swallow the trailing error, then
+  # symlink the dist bundle into opencode's plugins dir ourselves.
+  #
+  # We do NOT inject anything into ~/.config/opencode/AGENTS.md — that path is
+  # owned by modules/ai/instructions (read-only nix symlink). The plugin still
+  # captures sessions to the SQLite DB; agents query memory via the MCP tools
+  # rather than via auto-injected per-session context blobs.
   home.activation.installClaudeMemOpencodePlugin = lib.hm.dag.entryAfter [ "writeBoundary" ] ''
-    if [ ! -f "$HOME/.config/opencode/plugins/claude-mem.js" ]; then
-      echo "Installing claude-mem opencode plugin..."
-      ${pkgs.nodejs}/bin/npx -y claude-mem install --ide opencode \
-        || echo "WARNING: claude-mem opencode install failed — run \`npx claude-mem install --ide opencode\` manually"
+    PLUGIN_DEST="$HOME/.config/opencode/plugins/claude-mem.js"
+    PLUGIN_SRC="$HOME/.claude/plugins/marketplaces/thedotmack/dist/opencode-plugin/index.js"
+
+    if [ ! -e "$PLUGIN_DEST" ]; then
+      # Bootstrap the marketplace dist if it is not already present.
+      # npm/npx ship inside pkgs.nodejs — there is no separate pkgs.npm — and
+      # the npx wrapper needs `node` on PATH for its #!/usr/bin/env node shebang.
+      if [ ! -f "$PLUGIN_SRC" ]; then
+        echo "Bootstrapping claude-mem marketplace dist via npx..."
+        PATH="${pkgs.nodejs}/bin:$PATH" npx -y claude-mem install --ide opencode || true
+      fi
+
+      # Symlink (not copy) so subsequent `npx claude-mem install` runs that
+      # update the marketplace dist also update the opencode plugin file.
+      if [ -f "$PLUGIN_SRC" ]; then
+        mkdir -p "$(dirname "$PLUGIN_DEST")"
+        ln -sf "$PLUGIN_SRC" "$PLUGIN_DEST"
+        echo "claude-mem opencode plugin linked: $PLUGIN_DEST -> $PLUGIN_SRC"
+      else
+        echo "WARNING: claude-mem marketplace dist missing — run \`npx claude-mem install --ide opencode\` manually"
+      fi
     fi
   '';
 }

--- a/modules/ai/harnesses/opencode/default.nix
+++ b/modules/ai/harnesses/opencode/default.nix
@@ -41,4 +41,23 @@ in
     rm -f "$HOME/.config/opencode/oh-my-openagent.json.migrations.json"
     rm -rf "$HOME/.cache/opencode/packages/oh-my-openagent@latest"
   '';
+
+  # Install the claude-mem opencode plugin if it is missing. The MCP server
+  # is registered declaratively in modules/ai/mcp/default.nix; this hook
+  # provides the matching session/tool capture plugin so opencode also
+  # writes to the shared ~/.claude-mem/claude-mem.db that claude-code uses.
+  #
+  # The installer copies a JS bundle from the npm package's prebuilt dist/
+  # to ~/.config/opencode/plugins/claude-mem.js. It also tries to inject a
+  # placeholder into ~/.config/opencode/AGENTS.md, which fails silently here
+  # because that path is owned by the instructions module — the plugin still
+  # captures sessions, but auto-injected memory context is not surfaced in
+  # AGENTS.md (query memory via the claude-mem MCP tools instead).
+  home.activation.installClaudeMemOpencodePlugin = lib.hm.dag.entryAfter [ "writeBoundary" ] ''
+    if [ ! -f "$HOME/.config/opencode/plugins/claude-mem.js" ]; then
+      echo "Installing claude-mem opencode plugin..."
+      ${pkgs.nodejs}/bin/npx -y claude-mem install --ide opencode \
+        || echo "WARNING: claude-mem opencode install failed — run \`npx claude-mem install --ide opencode\` manually"
+    fi
+  '';
 }

--- a/modules/ai/mcp/default.nix
+++ b/modules/ai/mcp/default.nix
@@ -1,4 +1,5 @@
 {
+  config,
   pkgs,
   ...
 }:
@@ -17,6 +18,18 @@
       grep = {
         type = "http";
         url = "https://mcp.grep.app";
+      };
+      # claude-mem MCP search tools (search / timeline / get_observations).
+      # Workaround for upstream issue #2295 — opencode integration does not
+      # auto-register the MCP server. The CJS bundle is installed under the
+      # claude-code marketplace cache (claude-mem@thedotmack is enabled there).
+      # See modules/ai/harnesses/opencode/default.nix for the plugin install.
+      claude-mem = {
+        type = "stdio";
+        command = "${pkgs.nodejs}/bin/node";
+        args = [
+          "${config.home.homeDirectory}/.claude/plugins/marketplaces/thedotmack/plugin/scripts/mcp-server.cjs"
+        ];
       };
     };
   };


### PR DESCRIPTION
## Summary

Wire claude-mem into opencode so opencode also captures sessions to the shared SQLite memory at `~/.claude-mem/claude-mem.db` (which claude-code already populates), and so opencode can query that memory via MCP search tools.

## Two parts

1. **Declarative MCP server registration** in `modules/ai/mcp/default.nix` — exposes `search`, `timeline`, `get_observations` tools by pointing at the `mcp-server.cjs` shipped in the claude-code marketplace cache (which is already populated because `claude-mem@thedotmack` is enabled in `claude-code/default.nix`). Workaround for upstream [issue #2295](https://github.com/thedotmack/claude-mem/issues/2295) — the opencode installer does not auto-register the MCP server.

2. **First-boot activation hook** in `modules/ai/harnesses/opencode/default.nix` — runs `npx claude-mem install --ide opencode` only when `~/.config/opencode/plugins/claude-mem.js` is missing. Reading [the installer source](https://github.com/thedotmack/claude-mem/blob/main/src/services/integrations/OpenCodeInstaller.ts), it just copies the prebuilt JS bundle to that path. The hook is idempotent (no-op once the file exists), uses `${pkgs.nodejs}/bin/npx` for a stable npx, and gracefully degrades to a warning if the install fails (e.g., offline switch).

## Why not fully declarative for the plugin file?

I checked: the prebuilt `dist/opencode-plugin/index.js` bundle is NOT in the claude-code marketplace cache on disk — only the source. The bundle ships inside the `claude-mem` npm package. Vendoring `claude-mem` into nix is high maintenance vs. letting the upstream installer fetch + extract once.

## Known trade-off (called out in commit body)

The installer also seeds a placeholder into `~/.config/opencode/AGENTS.md`. That path is owned by `modules/ai/instructions` (read-only nix symlink) so the seeding fails silently — no harm done, just a `WARNING: ...` line. Practical effect: sessions are still captured to the DB and the agent can pull memory on demand via the MCP tools — the only thing missing is auto-injected per-session context as a markdown blob inside AGENTS.md.

## Test plan

- [x] `nix flake check --no-build` passes (both `darwinConfigurations` evaluate)
- [x] Rendered MCP entry on work host:
  - `command=/nix/store/.../nodejs-24.14.1/bin/node`
  - `args[0]=/Users/matthewthomas/.claude/plugins/marketplaces/thedotmack/plugin/scripts/mcp-server.cjs`
  - `type=stdio`
- [x] `mcp-server.cjs` confirmed present on work host (358KB, exec bit set)
- [x] `treefmt`, `statix`, `deadnix`, `flake-check` pre-commit hooks pass
- [ ] `switch` on work host
- [ ] `switch` on personal host
- [ ] After switch: `~/.config/opencode/plugins/claude-mem.js` exists
- [ ] Open opencode and try `/mcp` or just have an agent invoke `claude-mem` MCP tools
- [ ] Verify a fresh opencode session writes observations to `~/.claude-mem/claude-mem.db`