### PR TITLE
ai: split instructions into base/work/personal segments + add gws CLI for work

### DIFF
--- a/devenv.lock
+++ b/devenv.lock
@@ -3,11 +3,11 @@
     "devenv": {
       "locked": {
         "dir": "src/modules",
-        "lastModified": 1778071019,
-        "narHash": "sha256-vb4UzOKKdLext4faiI1KbI0yrTKNdI8wyxHvOMycWd8=",
+        "lastModified": 1778159535,
+        "narHash": "sha256-Iwd5ETa/f6gKBx0iejt/E6b1NXsiXSEzY7tL73+x7SU=",
         "owner": "cachix",
         "repo": "devenv",
-        "rev": "a3ebee0b80ce56ae4acba2c971c09ee6eca75338",
+        "rev": "747d4b3fe5fdefe9577537c557d2cc268fdbd8a1",
         "type": "github"
       },
       "original": {
@@ -78,11 +78,11 @@
     },
     "nixpkgs": {
       "locked": {
-        "lastModified": 1778036283,
-        "narHash": "sha256-62EWg6lI0qyzm7oAx5cAnGkLutvJsRBe0KkEW2JDZCE=",
+        "lastModified": 1778071213,
+        "narHash": "sha256-IoQY5s2VV3RDkX7iuONN9avQl07ItPwcvQWiqwDdfkQ=",
         "owner": "NixOS",
         "repo": "nixpkgs",
-        "rev": "ed67bc86e84e51d4a88e73c7fd36006dc876476f",
+        "rev": "07800bee2b362f6c73fe17cb1593a260c5e183c6",
         "type": "github"
       },
       "original": {

--- a/flake.lock
+++ b/flake.lock
@@ -26,11 +26,11 @@
     "agent-browser-skills": {
       "flake": false,
       "locked": {
-        "lastModified": 1778082499,
-        "narHash": "sha256-0EXHgpKAG489RIkEfGB16PzIy/83SPOY2ejR4+tWhVg=",
+        "lastModified": 1778162892,
+        "narHash": "sha256-tL3xfDraLFd/eTvEs3KEfemrUN7qmktUEwMEh+A+qxg=",
         "owner": "vercel-labs",
         "repo": "agent-browser",
-        "rev": "3bb1d43f8bb16444596365496f78395da8f1e6b7",
+        "rev": "d33bdb36f3f7793c977e8c503e5962721b275db8",
         "type": "github"
       },
       "original": {
@@ -138,11 +138,11 @@
     "chrome-devtools-mcp-skills": {
       "flake": false,
       "locked": {
-        "lastModified": 1778107819,
-        "narHash": "sha256-KnOV1Bi78ccBe2p9juOV2+FgXqVFOjrwfG4SgJrJPpA=",
+        "lastModified": 1778162354,
+        "narHash": "sha256-XloCpASqpbzonhi/5rV2bArAi6qVGDnsQCLGQTdfp18=",
         "owner": "ChromeDevTools",
         "repo": "chrome-devtools-mcp",
-        "rev": "d842de167b70dd349873fd68318333353ee49c68",
+        "rev": "faac61d2f2935334040ffd020668ac3ad9d2ab43",
         "type": "github"
       },
       "original": {
@@ -352,11 +352,11 @@
         ]
       },
       "locked": {
-        "lastModified": 1778110974,
-        "narHash": "sha256-7V7bW5uZSdKPRmemMQUulXRffnlnjRj5N/HGHOsOda8=",
+        "lastModified": 1778144356,
+        "narHash": "sha256-dGM+QCstz/DyLB68+JK5GWyMx4QSqmOJEVgZmy63d/g=",
         "owner": "nix-community",
         "repo": "home-manager",
-        "rev": "75fac363324f18d2b83a30fd916e509d2a02fb0e",
+        "rev": "e4419d3123b780d5f4c0bceeace450424387638c",
         "type": "github"
       },
       "original": {
@@ -423,11 +423,11 @@
         "treefmt-nix": "treefmt-nix"
       },
       "locked": {
-        "lastModified": 1778116483,
-        "narHash": "sha256-twEQQJieaLgDhYn3jCTz+8bi8/M+km+HTxWPqgordKw=",
+        "lastModified": 1778135581,
+        "narHash": "sha256-ASbg84F3mAv5lrQxWMEfO4hMuM0RzTMVgnr9LvMXQvw=",
         "owner": "numtide",
         "repo": "llm-agents.nix",
-        "rev": "29c22b867ba30fcabdc7089e7ca88e0cf00d829b",
+        "rev": "c19d3d1ee3dd4f501cf1ab0f87cef6ef4df0579e",
         "type": "github"
       },
       "original": {
@@ -470,11 +470,11 @@
     },
     "nixpkgs_3": {
       "locked": {
-        "lastModified": 1778036283,
-        "narHash": "sha256-62EWg6lI0qyzm7oAx5cAnGkLutvJsRBe0KkEW2JDZCE=",
+        "lastModified": 1778071213,
+        "narHash": "sha256-IoQY5s2VV3RDkX7iuONN9avQl07ItPwcvQWiqwDdfkQ=",
         "owner": "NixOS",
         "repo": "nixpkgs",
-        "rev": "ed67bc86e84e51d4a88e73c7fd36006dc876476f",
+        "rev": "07800bee2b362f6c73fe17cb1593a260c5e183c6",
         "type": "github"
       },
       "original": {
@@ -503,11 +503,11 @@
     "pup-skills": {
       "flake": false,
       "locked": {
-        "lastModified": 1778094191,
-        "narHash": "sha256-KLK14Q1kx+NualZPJFVROBYT+7SN3TXw7Ry7VZWfNwY=",
+        "lastModified": 1778121021,
+        "narHash": "sha256-q9P+RaWfnHGOiRdsZD+XKoABjPswQvR6s3WTpV/Q7LY=",
         "owner": "datadog-labs",
         "repo": "pup",
-        "rev": "ceace920393171b3dcd4fb37ace081aa0c0052a6",
+        "rev": "6e5310b14a84d52ffb5a4cd2e5b9e68803bdd6d4",
         "type": "github"
       },
       "original": {
@@ -661,11 +661,11 @@
     "worktrunk-skills": {
       "flake": false,
       "locked": {
-        "lastModified": 1778090091,
-        "narHash": "sha256-kwwDi6DGz2u4Yrdyt6mXKIP38vQfpi7H6J9sOEKAPYQ=",
+        "lastModified": 1778141575,
+        "narHash": "sha256-IRfrd3qh7ewcBA+95XqkCfuVOH3cCHUmdJVbEUNhPVw=",
         "owner": "max-sixty",
         "repo": "worktrunk",
-        "rev": "404bd563a54ec7ff5e15a913ed6ad76e812b7b6f",
+        "rev": "ab45e004e57ab82365d13ef19fb0b2cbe0c78de4",
         "type": "github"
       },
       "original": {

--- a/hosts/work.nix
+++ b/hosts/work.nix
@@ -44,6 +44,7 @@ mkHost {
     (pkg "git")
     (pkg "git-absorb")
     (pkg "git-machete")
+    (pkg "gws")
     (pkg "lazygit")
     (pkg "linear")
     (pkg "mise")

--- a/modules/ai/harnesses/codex/default.nix
+++ b/modules/ai/harnesses/codex/default.nix
@@ -1,11 +1,15 @@
 {
   pkgs,
+  inputs,
   ...
 }:
 {
   programs.codex = {
     enable = true;
-    package = pkgs.codex;
+    # Use the pre-built codex from llm-agents.nix (numtide) so we hit
+    # cache.numtide.com instead of building from source against nixpkgs.
+    # Mirrors how opencode is wired in ../opencode/default.nix.
+    package = inputs.llm-agents.packages.${pkgs.stdenv.hostPlatform.system}.codex;
     enableMcpIntegration = true;
     settings = {
       approval_policy = "never";

--- a/modules/ai/instructions/INSTRUCTIONS.md
+++ b/modules/ai/instructions/INSTRUCTIONS.md
@@ -31,21 +31,3 @@ Use the **agent-browser** skill. Only use Chrome DevTools MCP when I explicitly 
 Use the **git-machete** skill (`/git-machete`). Use `git m` (alias for `git machete`) to manage stacked branch trees and create PRs that show their position in the stack.
 
 </important>
-
-<important if="you are working with Datadog — monitors, dashboards, logs, APM, incidents, or any observability task">
-
-Use the **pup** skill (`/dd-pup`) for Datadog CLI operations. Related skills: `/dd-logs`, `/dd-apm`, `/dd-monitors`, `/dd-debugger`.
-
-</important>
-
-<important if="you are managing Linear issues, creating tickets, updating status, or working with project tracking">
-
-Use the **linear-cli** skill (`/linear-cli`) to manage Linear issues from the command line.
-
-</important>
-
-<important if="you are managing git worktrees, configuring worktrunk, setting up hooks, or using wt commands">
-
-Use the **worktrunk** skill (`/worktrunk`) for worktree management, hooks, and commit message generation.
-
-</important>

--- a/modules/ai/instructions/default.nix
+++ b/modules/ai/instructions/default.nix
@@ -1,7 +1,38 @@
-_: {
-  home.file = {
-    ".claude/CLAUDE.md".source = ./INSTRUCTIONS.md;
-    ".codex/AGENTS.md".source = ./INSTRUCTIONS.md;
-    ".config/opencode/AGENTS.md".source = ./INSTRUCTIONS.md;
+{
+  lib,
+  config,
+  pkgs,
+  ...
+}:
+let
+  cfg = config.programs.aiInstructions;
+  mergedFile = pkgs.writeText "ai-instructions.md" (
+    lib.concatMapStringsSep "\n\n" builtins.readFile cfg.segments
+  );
+in
+{
+  options.programs.aiInstructions = {
+    segments = lib.mkOption {
+      type = lib.types.listOf lib.types.path;
+      default = [ ];
+      description = ''
+        Markdown files concatenated (in order) to form the final AI instructions
+        file deployed to every configured harness (Claude Code, Codex, OpenCode).
+        The base module contributes `INSTRUCTIONS.md`; host aggregators
+        (`work.nix`, `personal.nix`) append their own segments.
+      '';
+    };
+  };
+
+  config = {
+    # Anchor the base instructions at the start of the merged file. Host
+    # aggregators (work.nix / personal.nix) append their own segments after.
+    programs.aiInstructions.segments = lib.mkBefore [ ./INSTRUCTIONS.md ];
+
+    home.file = {
+      ".claude/CLAUDE.md".source = mergedFile;
+      ".codex/AGENTS.md".source = mergedFile;
+      ".config/opencode/AGENTS.md".source = mergedFile;
+    };
   };
 }

--- a/modules/ai/instructions/personal.md
+++ b/modules/ai/instructions/personal.md
@@ -1,0 +1,5 @@
+# Personal Instructions
+
+Personal-host-only preferences. Merged on top of the base instructions.
+
+<!-- Add personal-only `<important if="...">` blocks here. -->

--- a/modules/ai/instructions/personal.nix
+++ b/modules/ai/instructions/personal.nix
@@ -1,0 +1,3 @@
+_: {
+  programs.aiInstructions.segments = [ ./personal.md ];
+}

--- a/modules/ai/instructions/work.md
+++ b/modules/ai/instructions/work.md
@@ -1,0 +1,21 @@
+# Work Instructions
+
+Work-host-only preferences. Merged on top of the base instructions.
+
+<important if="you are working with Datadog — monitors, dashboards, logs, APM, incidents, or any observability task">
+
+Use the **pup** skill (`/dd-pup`) for Datadog CLI operations. Related skills: `/dd-logs`, `/dd-apm`, `/dd-monitors`, `/dd-debugger`.
+
+</important>
+
+<important if="you are managing Linear issues, creating tickets, updating status, or working with project tracking">
+
+Use the **linear-cli** skill (`/linear-cli`) to manage Linear issues from the command line.
+
+</important>
+
+<important if="you are managing git worktrees, configuring worktrunk, setting up hooks, or using wt commands">
+
+Use the **worktrunk** skill (`/worktrunk`) for worktree management, hooks, and commit message generation.
+
+</important>

--- a/modules/ai/instructions/work.md
+++ b/modules/ai/instructions/work.md
@@ -2,6 +2,23 @@
 
 Work-host-only preferences. Merged on top of the base instructions.
 
+<important if="I ask you to search, read, or send Gmail; check my calendar or upcoming meetings; or look at files in my Google Drive">
+
+Use the **`gws`** CLI (Google Workspace CLI) — it is installed on this host. It wraps the Google Workspace APIs with my work account credentials.
+
+Common patterns:
+
+- **Gmail**: `gws gmail users.messages list --params '{"q": "from:someone@example.com", "maxResults": 10}'`, then `gws gmail users.messages get --params '{"id": "<id>", "format": "full"}'` to read a thread.
+- **Calendar**: `gws calendar +agenda` for upcoming events. `gws calendar events.list --params '{"timeMin": "...", "timeMax": "..."}'` for a custom range.
+- **Drive**: `gws drive files list --params '{"q": "name contains '"'"'foo'"'"'", "pageSize": 20}'` to search; `gws drive files get --params '{"fileId": "<id>"}'` for metadata; `gws drive files export` to download as text.
+- **Helpers**: `+send`, `+reply`, `+reply-all`, `+forward`, `+triage`, `+watch` (Gmail); `+insert`, `+agenda` (Calendar); `+upload` (Drive).
+
+If `gws auth login` has not been run yet, tell me — auth is interactive and I have to do it.
+
+Prefer `gws` over scraping the Gmail / Calendar / Drive web UI via playwriter or agent-browser. Only fall back to a browser if a workflow is genuinely UI-only (e.g. shared-drive permission dialogs).
+
+</important>
+
 <important if="you are working with Datadog — monitors, dashboards, logs, APM, incidents, or any observability task">
 
 Use the **pup** skill (`/dd-pup`) for Datadog CLI operations. Related skills: `/dd-logs`, `/dd-apm`, `/dd-monitors`, `/dd-debugger`.

--- a/modules/ai/instructions/work.nix
+++ b/modules/ai/instructions/work.nix
@@ -1,0 +1,3 @@
+_: {
+  programs.aiInstructions.segments = [ ./work.md ];
+}

--- a/modules/ai/personal.nix
+++ b/modules/ai/personal.nix
@@ -3,5 +3,6 @@
     ./harnesses/opencode/personal.nix
     ./skills/personal.nix
     ./mcp/personal.nix
+    ./instructions/personal.nix
   ];
 }

--- a/modules/ai/work.nix
+++ b/modules/ai/work.nix
@@ -3,5 +3,6 @@
     ./harnesses/opencode/work.nix
     ./skills/work.nix
     ./mcp/work.nix
+    ./instructions/work.nix
   ];
 }

--- a/modules/home-manager/packages/gws/default.nix
+++ b/modules/home-manager/packages/gws/default.nix
@@ -1,0 +1,7 @@
+{
+  pkgs,
+  ...
+}:
+{
+  home.packages = [ pkgs.gws ];
+}


### PR DESCRIPTION
## Summary

Two related changes to the AI instructions system:

1. **Refactor `modules/ai/instructions` into a merge engine.** `default.nix` now exposes `programs.aiInstructions.segments` (a `listOf path`) and concatenates each segment via `pkgs.writeText` into one file deployed to all three harness paths (`~/.claude/CLAUDE.md`, `~/.codex/AGENTS.md`, `~/.config/opencode/AGENTS.md`). The base `INSTRUCTIONS.md` is anchored first via `lib.mkBefore`; host aggregators contribute their own segments after.
2. **Add `gws` (Google Workspace CLI) for the work host** so AI tools can search Gmail, Calendar, and Drive without a browser, with a matching `<important if>` block in `work.md`.

## Why split base / work / personal

Several skills are work-only (`dd-*`, `linear-cli`, `worktrunk` per `modules/ai/skills/work.nix`), so their instruction blocks shouldn't appear in the base file the personal host gets. The work-only blocks moved out of `INSTRUCTIONS.md` into `work.md`. `personal.md` is empty scaffolding for future personal-only blocks.

This mirrors the existing pattern used by `harnesses/`, `skills/`, `mcp/` — each subdirectory has `default.nix` (base) + `work.nix` + `personal.nix` aggregators imported by `modules/ai/{work,personal}.nix`.

## File map

| Path | Content |
|---|---|
| `modules/ai/instructions/default.nix` | Merge engine + `programs.aiInstructions.segments` option, contributes `INSTRUCTIONS.md` |
| `modules/ai/instructions/INSTRUCTIONS.md` | Base (universal): context7, Exa, playwriter, agent-browser, git-machete |
| `modules/ai/instructions/work.{nix,md}` | Work-only: gws, pup + dd-*, linear-cli, worktrunk |
| `modules/ai/instructions/personal.{nix,md}` | Empty placeholder |
| `modules/home-manager/packages/gws/default.nix` | `home.packages = [ pkgs.gws ];` |
| `hosts/work.nix` | `(pkg "gws")` added |

## Verification

- `format` clean, `lint` (statix) clean, `nix flake check --no-build` passes.
- Pre-commit hooks (deadnix / flake-check / statix / treefmt) green on both commits.
- Built and inspected the merged file for both hosts:
  - Work merged segments: `[INSTRUCTIONS.md, work.md]` → base universal blocks first, then gws + dd-* + linear + worktrunk.
  - Personal merged segments: `[INSTRUCTIONS.md, personal.md]` → just the universal blocks (placeholder is comment-only).
- Confirmed `gws-0.22.5` lands in the work host's `home.packages` and is absent on personal.

## Follow-ups (not in this PR)

- After `switch` on the work box, run `gws auth setup` then `gws auth login` once — auth is interactive OAuth, can't be Nix-managed; tokens go in the macOS keyring.
- Open question: co-locate per-skill instruction snippets with the skill enable, so adding/removing a skill auto-includes/removes its instruction block. Researched but not implemented here.