### PR TITLE
feat(ai/work): replace slack mcp with agent-slack CLI + skill

### DIFF
--- a/flake.lock
+++ b/flake.lock
@@ -60,6 +60,27 @@
         "type": "github"
       }
     },
+    "agent-slack": {
+      "inputs": {
+        "flake-utils": "flake-utils",
+        "nixpkgs": [
+          "nixpkgs"
+        ]
+      },
+      "locked": {
+        "lastModified": 1777963306,
+        "narHash": "sha256-kv4VNACqDhwI/FSZhESsdbJ1veRbPx6+4Vf1odKC3KI=",
+        "owner": "stablyai",
+        "repo": "agent-slack",
+        "rev": "4a9bd21fad0c402940d725d828321ceac32e4fca",
+        "type": "github"
+      },
+      "original": {
+        "owner": "stablyai",
+        "repo": "agent-slack",
+        "type": "github"
+      }
+    },
     "anthropic-skills": {
       "flake": false,
       "locked": {
@@ -153,7 +174,7 @@
     },
     "claude-code-nix": {
       "inputs": {
-        "flake-utils": "flake-utils",
+        "flake-utils": "flake-utils_2",
         "nixpkgs": "nixpkgs"
       },
       "locked": {
@@ -303,6 +324,24 @@
         "type": "github"
       }
     },
+    "flake-utils_2": {
+      "inputs": {
+        "systems": "systems_3"
+      },
+      "locked": {
+        "lastModified": 1731533236,
+        "narHash": "sha256-l0KFg5HjrsfsO/JpG+r7fRrqm12kzFHyUHqHCVpMMbI=",
+        "owner": "numtide",
+        "repo": "flake-utils",
+        "rev": "11707dc2f618dd54ca8739b309ec4fc024de578b",
+        "type": "github"
+      },
+      "original": {
+        "owner": "numtide",
+        "repo": "flake-utils",
+        "type": "github"
+      }
+    },
     "home-manager": {
       "inputs": {
         "nixpkgs": [
@@ -419,7 +458,7 @@
         "bun2nix": "bun2nix",
         "flake-parts": "flake-parts_2",
         "nixpkgs": "nixpkgs_2",
-        "systems": "systems_3",
+        "systems": "systems_4",
         "treefmt-nix": "treefmt-nix"
       },
       "locked": {
@@ -521,6 +560,7 @@
         "agenix": "agenix",
         "agent-browser-skills": "agent-browser-skills",
         "agent-skills-nix": "agent-skills-nix",
+        "agent-slack": "agent-slack",
         "anthropic-skills": "anthropic-skills",
         "chrome-devtools-mcp-skills": "chrome-devtools-mcp-skills",
         "claude-code-nix": "claude-code-nix",
@@ -590,6 +630,21 @@
       }
     },
     "systems_3": {
+      "locked": {
+        "lastModified": 1681028828,
+        "narHash": "sha256-Vy1rq5AaRuLzOxct8nz4T6wlgyUR7zLU309k9mBC768=",
+        "owner": "nix-systems",
+        "repo": "default",
+        "rev": "da67096a3b9bf56a91d16901293e51ba5b49a27e",
+        "type": "github"
+      },
+      "original": {
+        "owner": "nix-systems",
+        "repo": "default",
+        "type": "github"
+      }
+    },
+    "systems_4": {
       "locked": {
         "lastModified": 1681028828,
         "narHash": "sha256-Vy1rq5AaRuLzOxct8nz4T6wlgyUR7zLU309k9mBC768=",

--- a/flake.nix
+++ b/flake.nix
@@ -25,6 +25,9 @@
     agent-skills-nix.url = "github:Kyure-A/agent-skills-nix";
     agent-skills-nix.inputs.nixpkgs.follows = "nixpkgs";
 
+    agent-slack.url = "github:stablyai/agent-slack";
+    agent-slack.inputs.nixpkgs.follows = "nixpkgs";
+
     anthropic-skills = {
       url = "github:anthropics/skills";
       flake = false;

--- a/hosts/work.nix
+++ b/hosts/work.nix
@@ -30,6 +30,7 @@ mkHost {
   packages = [
     (pkg "agenix")
     (pkg "aerospace")
+    (pkg "agent-slack")
     (pkg "bat")
     (pkg "bun")
     (pkg "dock")

--- a/modules/ai/instructions/INSTRUCTIONS.md
+++ b/modules/ai/instructions/INSTRUCTIONS.md
@@ -8,6 +8,35 @@ Use **context7** first — it has up-to-date docs with code examples. Fall back 
 
 </important>
 
+<important if="you encounter ambiguity, edge cases, or seemingly conflicting rules in a project's AGENTS.md, CLAUDE.md, or similar instruction files">
+
+**Do not rationalize-and-proceed.** When a rule is unclear at the edges:
+
+1. **Default to the strict literal reading** of the rule. Edge cases resolve in favor of the rule.
+2. **If still genuinely ambiguous**, ask ONE focused question and stop. Do not act under a guessed interpretation.
+
+NEVER write narration that combines unilateral action with soft permission-seeking. This pattern — identifying ambiguity, resolving it yourself, then saying "but the user can override if needed" — is forbidden.
+
+Canonical bad example (do NOT do this):
+
+> "On the AGENTS.md rule about prefixing agent-posted comments: the PR close comment will be posted under the user's identity rather than a bot account, which creates some ambiguity. I'll default to adding the [Claude Code] prefix since that's what the rule specifies, but the user can override if needed. For the auto-resolve items, I'll add the prefix, save the Slack reply to the specified path, and leave the branch intact until the user decides."
+
+Why this is forbidden:
+
+- It identifies ambiguity, then resolves it unilaterally
+- It wraps the action in "but you can override" language to dodge commitment to either following or asking
+- It bundles multiple unrelated decisions ("for the auto-resolve items, I'll do A, B, and C") as a fait accompli
+- It reads like internal monologue posing as communication
+
+The correct alternatives:
+
+- **Follow strictly**: "The rule says prefix with [Claude Code]. Doing so." (No narration.)
+- **Or ask once**: "The PR close comment will post under your identity, not a bot — should I still apply the [Claude Code] prefix?" Then stop and wait.
+
+Never both, never bundled, never narrated.
+
+</important>
+
 <important if="you need to search the web for information">
 
 Use **Exa** (MCP server) first — higher quality, focused results. Fall back to generic web search only when Exa doesn't cover the topic.

--- a/modules/ai/instructions/INSTRUCTIONS.md
+++ b/modules/ai/instructions/INSTRUCTIONS.md
@@ -60,3 +60,9 @@ Use the **agent-browser** skill. Only use Chrome DevTools MCP when I explicitly 
 Use the **git-machete** skill (`/git-machete`). Use `git m` (alias for `git machete`) to manage stacked branch trees and create PRs that show their position in the stack.
 
 </important>
+
+<important if="you need to read or send a Slack message, search Slack, browse channel history, or interact with Slack in any way">
+
+Use the **agent-slack** skill (`/agent-slack`). Run `agent-slack` CLI commands — it handles messages, threads, search, reactions, channels, and more. Auth is already bootstrapped.
+
+</important>

--- a/modules/ai/mcp/work.nix
+++ b/modules/ai/mcp/work.nix
@@ -17,13 +17,5 @@ _: {
         "chrome-devtools-mcp@latest"
       ];
     };
-    slack = {
-      type = "remote";
-      url = "https://mcp.slack.com/mcp";
-      oauth = {
-        clientId = "1601185624273.8899143856786";
-        callbackPort = 3118;
-      };
-    };
   };
 }

--- a/modules/ai/skills/work.nix
+++ b/modules/ai/skills/work.nix
@@ -18,6 +18,10 @@ _: {
         input = "chrome-devtools-mcp-skills";
         subdir = "skills";
       };
+      agent-slack = {
+        input = "agent-slack";
+        subdir = "skills";
+      };
     };
     skills.enable = [
       "dd-pup"
@@ -37,6 +41,7 @@ _: {
       "debug-optimize-lcp"
       "memory-leak-debugging"
       "troubleshooting"
+      "agent-slack"
     ];
   };
 }

--- a/modules/home-manager/packages/agent-slack/default.nix
+++ b/modules/home-manager/packages/agent-slack/default.nix
@@ -1,0 +1,8 @@
+{
+  inputs,
+  pkgs,
+  ...
+}:
+{
+  home.packages = [ inputs.agent-slack.packages.${pkgs.stdenv.hostPlatform.system}.default ];
+}


### PR DESCRIPTION
## Summary

- Replaces the remote Slack MCP server with the `stablyai/agent-slack` CLI + skill
- Adds `agent-slack` flake input and dedicated package module (`modules/home-manager/packages/agent-slack/`)
- Enables `agent-slack` skill on the work host via `modules/ai/skills/work.nix`
- Removes the `slack` remote MCP entry from `modules/ai/mcp/work.nix`
- Adds anti-rationalization `<important if>` rule to `INSTRUCTIONS.md`
- Adds Slack trigger `<important if>` block to `INSTRUCTIONS.md` so AI tools know to use `agent-slack`

## Changes

- `flake.nix` / `flake.lock` — new `agent-slack` input
- `modules/home-manager/packages/agent-slack/default.nix` — new package module
- `hosts/work.nix` — adds `(pkg "agent-slack")`
- `modules/ai/skills/work.nix` — adds source + enables skill
- `modules/ai/mcp/work.nix` — removes `slack` MCP entry
- `modules/ai/instructions/INSTRUCTIONS.md` — anti-rationalization rule + Slack trigger block