### PR TITLE
feat(ai/opencode): enable team-mode for parallel multi-agent coordination

### DIFF
--- a/modules/ai/harnesses/opencode/oh-my-openagent-base.nix
+++ b/modules/ai/harnesses/opencode/oh-my-openagent-base.nix
@@ -38,6 +38,13 @@
     default_builder_enabled = false;
   };
 
+  team_mode = {
+    enabled = true;
+    max_parallel_members = 4;
+    max_members = 8;
+    tmux_visualization = false;
+  };
+
   background_task = {
     providerConcurrency = {
       anthropic = 3;


### PR DESCRIPTION
## Summary

- Enables `team_mode` in oh-my-openagent base config — exposes the 12 `team_*` tools for persistent multi-agent coordination
- Applies to both personal and work hosts (added to shared base, not host-specific override)
- Defaults match upstream docs example: 4 parallel / 8 max members, `tmux_visualization` off

## What it gives me

Team-mode adds persistent multi-agent coordination on top of regular `delegate-task` — members share a mailbox and task list, lead orchestrates. Useful for long-running refactors and research+impl pipelines that need bounded parallelism with shared state.

New tools: `team_create`, `team_delete`, `team_send_message`, `team_task_create` / `_list` / `_update` / `_get`, `team_status`, `team_list`, `team_shutdown_request`, `team_approve_shutdown`, `team_reject_shutdown`.

## Test plan

- `format` clean
- `lint` clean
- `switch` applied successfully on personal host
- Verified `team_mode` block present in `~/.config/opencode/oh-my-openagent.json`
- Restart opencode to pick up the new tools

## Notes

- Eligible agents: `sisyphus`, `atlas`, `sisyphus-junior` (conditionally `hephaestus`)
- Read-only agents (`oracle`, `librarian`, `explore`, etc.) remain `delegate-task`-only — they can't write mailbox state
- Storage at `~/.omo/teams/` and `~/.omo/runtime/`
- `tmux_visualization = false` for now — flip to `true` if you want each member to get a live tmux pane via `opencode attach` (only kicks in when opencode runs inside tmux)

Docs: https://github.com/code-yeongyu/oh-my-openagent/blob/dev/docs/guide/team-mode.md