### PR TITLE
Install Orca (ADE) + orchestration skill

### DIFF
--- a/flake.lock
+++ b/flake.lock
@@ -522,6 +522,22 @@
         "type": "github"
       }
     },
+    "orca-skills": {
+      "flake": false,
+      "locked": {
+        "lastModified": 1779356023,
+        "narHash": "sha256-qMNX+XHJLujqaTrQ/VMGTCRLwiIHjtDB5ZYnnrQ395Q=",
+        "owner": "stablyai",
+        "repo": "orca",
+        "rev": "a7d77aabaa4ab7ac0e817920feb169b26493eedb",
+        "type": "github"
+      },
+      "original": {
+        "owner": "stablyai",
+        "repo": "orca",
+        "type": "github"
+      }
+    },
     "playwriter-skills": {
       "flake": false,
       "locked": {
@@ -573,6 +589,7 @@
         "linear-cli-skills": "linear-cli-skills",
         "llm-agents": "llm-agents",
         "nixpkgs": "nixpkgs_3",
+        "orca-skills": "orca-skills",
         "playwriter-skills": "playwriter-skills",
         "pup-skills": "pup-skills",
         "superpowers": "superpowers",

--- a/flake.nix
+++ b/flake.nix
@@ -98,6 +98,11 @@
       flake = false;
     };
 
+    orca-skills = {
+      url = "github:stablyai/orca";
+      flake = false;
+    };
+
   };
 
   outputs =

--- a/hosts/personal.nix
+++ b/hosts/personal.nix
@@ -28,6 +28,7 @@ mkHost {
     (app "spotify")
     (app "utm")
     (app "zed")
+    (app "orca")
     (app "ghostty")
   ];
 

--- a/hosts/work.nix
+++ b/hosts/work.nix
@@ -25,6 +25,7 @@ mkHost {
     # (app "spotify")
     (app "ghostty")
     (app "zed")
+    (app "orca")
   ];
 
   packages = [

--- a/modules/ai/skills/default.nix
+++ b/modules/ai/skills/default.nix
@@ -45,6 +45,10 @@
         input = "humanlayer-skills";
         subdir = "plugins/improve-claude-md/skills";
       };
+      orca = {
+        input = "orca-skills";
+        subdir = "skills";
+      };
       local = {
         path = ./git-machete;
       };
@@ -60,6 +64,7 @@
       "itechmeat/react-testing-library"
       "improve-claude-md"
       "git-machete"
+      "orchestration"
     ];
     targets = {
       claude.enable = true;

--- a/modules/home-manager/applications/orca/default.nix
+++ b/modules/home-manager/applications/orca/default.nix
@@ -1,0 +1,4 @@
+{ pkgs, ... }:
+{
+  home.packages = [ (pkgs.callPackage ./package.nix { }) ];
+}

--- a/modules/home-manager/applications/orca/package.nix
+++ b/modules/home-manager/applications/orca/package.nix
@@ -31,11 +31,22 @@ stdenvNoCC.mkDerivation {
 
   nativeBuildInputs = [ unzip ];
 
+  # The .app bundle is a signed Electron app. Nix's default fixupPhase patches
+  # shebangs in shell scripts inside the bundle, which invalidates the code
+  # signature and causes macOS Gatekeeper to refuse to launch it ("damaged").
+  # Disable fixup entirely and re-sign with an ad-hoc signature after install.
+  dontFixup = true;
+
   installPhase = ''
     runHook preInstall
     mkdir -p $out/Applications $out/bin
     cp -R "Orca.app" $out/Applications/
     ln -s $out/Applications/Orca.app/Contents/Resources/bin/orca $out/bin/orca
+
+    # Re-sign the bundle ad-hoc so Gatekeeper accepts it. Any prior signature
+    # was invalidated by the copy + Nix's store rewriting.
+    /usr/bin/codesign --force --deep --sign - "$out/Applications/Orca.app"
+
     runHook postInstall
   '';
 

--- a/modules/home-manager/applications/orca/package.nix
+++ b/modules/home-manager/applications/orca/package.nix
@@ -1,0 +1,52 @@
+{
+  lib,
+  stdenvNoCC,
+  fetchurl,
+  unzip,
+}:
+let
+  version = "1.4.16";
+
+  sources = {
+    aarch64-darwin = {
+      url = "https://github.com/stablyai/orca/releases/download/v${version}/Orca-${version}-arm64-mac.zip";
+      hash = "sha256-8SE6BDZmm9PvvILOwVv6RH3bSp+dwm8c4Q7Ail6p7z8=";
+    };
+    x86_64-darwin = {
+      url = "https://github.com/stablyai/orca/releases/download/v${version}/Orca-${version}-mac.zip";
+      hash = "sha256-a/8sSmH5pmTcmKkrr9/wyR7fFc/dNzGmu4lT8MhhkY4=";
+    };
+  };
+
+  system = stdenvNoCC.hostPlatform.system;
+  source = sources.${system} or (throw "orca: unsupported system ${system}");
+in
+stdenvNoCC.mkDerivation {
+  pname = "orca";
+  inherit version;
+
+  src = fetchurl source;
+
+  sourceRoot = ".";
+
+  nativeBuildInputs = [ unzip ];
+
+  installPhase = ''
+    runHook preInstall
+    mkdir -p $out/Applications $out/bin
+    cp -R "Orca.app" $out/Applications/
+    ln -s $out/Applications/Orca.app/Contents/Resources/bin/orca $out/bin/orca
+    runHook postInstall
+  '';
+
+  meta = {
+    description = "Agent Development Environment for running Claude Code, Codex, OpenCode side by side in isolated worktrees";
+    homepage = "https://www.onorca.dev/";
+    license = lib.licenses.mit;
+    platforms = [
+      "aarch64-darwin"
+      "x86_64-darwin"
+    ];
+    sourceProvenance = [ lib.sourceTypes.binaryNativeCode ];
+  };
+}


### PR DESCRIPTION
Install [Orca](https://www.onorca.dev/) (stablyai's Agent Development Environment) declaratively on both hosts, and wire in its `orchestration` skill.

## What

- **New derivation** `modules/home-manager/applications/orca/package.nix` — fetches the prebuilt arm64/x86_64 `.zip` from `stablyai/orca` v1.4.16 releases, installs `Orca.app` under `$out/Applications`, and exposes the `orca` CLI on PATH via `$out/bin/orca` → `Contents/Resources/bin/orca`.
- **Wire into both hosts** via `(app "orca")` in `hosts/personal.nix` and `hosts/work.nix`.
- **Orchestration skill** — adds `orca-skills` flake input pointing at `github:stablyai/orca` (non-flake) and registers it as a source under `programs.agent-skills.sources.orca`, enabling the `orchestration` skill globally.

## Why

Orca isn't in nixpkgs and the website-recommended path is a manual `.dmg` + `npx skills add ...`. Vendoring it here keeps both hosts reproducible and removes the imperative `npx` step.

## Test plan

- `nix flake check --no-build` — clean
- `nix-build` of the package — succeeded, `$out/Applications/Orca.app` present, `$out/bin/orca` symlink resolves into the bundle
- `treefmt` + `statix` + `deadnix` + `flake-check` pre-commit hooks all pass
- Next step on the box: `switch` to materialize on personal/work

## Notes

- The home-manager `copyApps` mechanism will surface `Orca.app` under `~/Applications/Home Manager Apps/`.
- Other skills available in the upstream repo (`computer-use`, `orca-cli`) are now sourceable but left disabled — add them to `skills.enable` if needed.
- Version bumps are a one-line `version =` + two hash updates (arm64 + x86_64) in `package.nix`.