### PR TITLE
Update opencode models to Opus 4.8

### DIFF
--- a/modules/ai/harnesses/opencode/oh-my-openagent-base.nix
+++ b/modules/ai/harnesses/opencode/oh-my-openagent-base.nix
@@ -50,7 +50,7 @@
       anthropic = 3;
     };
     modelConcurrency = {
-      "anthropic/claude-opus-4-7" = 2;
+      "anthropic/claude-opus-4-8" = 2;
     };
   };
 
@@ -89,7 +89,7 @@
   agents = {
     # Default opencode agent
     build = {
-      model = "anthropic/claude-opus-4-7";
+      model = "anthropic/claude-opus-4-8";
       thinking.type = "enabled";
       fallback_models = [
         "anthropic/claude-sonnet-4-6"
@@ -99,7 +99,7 @@
 
     # Primary orchestrator
     sisyphus = {
-      model = "anthropic/claude-opus-4-7";
+      model = "anthropic/claude-opus-4-8";
       thinking.type = "enabled";
       fallback_models = [
         "anthropic/claude-sonnet-4-6"
@@ -114,7 +114,7 @@
 
     # Planning & strategy
     prometheus = {
-      model = "anthropic/claude-opus-4-7";
+      model = "anthropic/claude-opus-4-8";
       thinking.type = "enabled";
       fallback_models = [
         "anthropic/claude-sonnet-4-6"
@@ -123,7 +123,7 @@
     };
 
     metis = {
-      model = "anthropic/claude-opus-4-7";
+      model = "anthropic/claude-opus-4-8";
       thinking.type = "enabled";
       fallback_models = [
         "anthropic/claude-sonnet-4-6"
@@ -133,7 +133,7 @@
 
     # Review — host configs may override model + add thinking/reasoningEffort
     momus = {
-      model = "anthropic/claude-opus-4-7";
+      model = "anthropic/claude-opus-4-8";
       thinking.type = "enabled";
       fallback_models = [
         "anthropic/claude-sonnet-4-6"
@@ -143,7 +143,7 @@
 
     # Architecture & debugging — host configs may override model + add thinking/reasoningEffort
     oracle = {
-      model = "anthropic/claude-opus-4-7";
+      model = "anthropic/claude-opus-4-8";
       thinking.type = "enabled";
       fallback_models = [
         "anthropic/claude-sonnet-4-6"
@@ -177,17 +177,17 @@
     quick.model = "anthropic/claude-haiku-4-5";
     unspecified-low.model = "anthropic/claude-sonnet-4-6";
     unspecified-high = {
-      model = "anthropic/claude-opus-4-7";
+      model = "anthropic/claude-opus-4-8";
       variant = "max";
       thinking.type = "enabled";
     };
     deep = {
-      model = "anthropic/claude-opus-4-7";
+      model = "anthropic/claude-opus-4-8";
       variant = "max";
       thinking.type = "enabled";
     };
     ultrabrain = {
-      model = "anthropic/claude-opus-4-7";
+      model = "anthropic/claude-opus-4-8";
       variant = "max";
       thinking.type = "enabled";
     };

--- a/modules/ai/harnesses/opencode/personal.nix
+++ b/modules/ai/harnesses/opencode/personal.nix
@@ -7,7 +7,7 @@ let
     disabled_agents = [ "hephaestus" ];
     agents = baseConfig.agents // {
       oracle = {
-        model = "anthropic/claude-opus-4-7";
+        model = "anthropic/claude-opus-4-8";
         thinking.type = "enabled";
         fallback_models = [
           "anthropic/claude-sonnet-4-6"
@@ -15,7 +15,7 @@ let
         compaction.model = "anthropic/claude-sonnet-4-6";
       };
       momus = {
-        model = "anthropic/claude-opus-4-7";
+        model = "anthropic/claude-opus-4-8";
         thinking.type = "enabled";
         fallback_models = [
           "anthropic/claude-sonnet-4-6"

--- a/modules/ai/harnesses/opencode/work.nix
+++ b/modules/ai/harnesses/opencode/work.nix
@@ -12,7 +12,7 @@ let
         variant = "high";
         reasoningEffort = "high";
         fallback_models = [
-          "anthropic/claude-opus-4-7"
+          "anthropic/claude-opus-4-8"
           "anthropic/claude-sonnet-4-6"
         ];
         compaction.model = "anthropic/claude-sonnet-4-6";
@@ -22,7 +22,7 @@ let
         model = "openai/gpt-5.5";
         variant = "high";
         fallback_models = [
-          "anthropic/claude-opus-4-7"
+          "anthropic/claude-opus-4-8"
           "anthropic/claude-sonnet-4-6"
         ];
         compaction.model = "anthropic/claude-sonnet-4-6";


### PR DESCRIPTION
## Summary

Opus 4.8 is now out. This bumps all explicit `anthropic/claude-opus-4-7` references to `claude-opus-4-8` across the opencode harness configs (14 occurrences).

## Changes

- `modules/ai/harnesses/opencode/oh-my-openagent-base.nix` (10)
- `modules/ai/harnesses/opencode/work.nix` (2)
- `modules/ai/harnesses/opencode/personal.nix` (2)

## Notes

- The claude-code `opus[1m]` shorthand in `modules/ai/harnesses/claude-code/default.nix` is left untouched — it doesn't pin a version and auto-resolves to the latest Opus (now 4.8).
- `sonnet-4-6` / `haiku-4-5` references were intentionally left as-is.

## Testing

- `nix flake check --no-build` passes
- pre-commit hooks (deadnix, flake-check, statix, treefmt) pass