### PR TITLE
CI host evaluation, opencode model centralization, docs sync, claude-mem tarball

### DIFF
--- a/.claude/skills/home-manager/SKILL.md
+++ b/.claude/skills/home-manager/SKILL.md
@@ -11,9 +11,9 @@ Always prefer `programs.*` over `home.packages`. Use the NixOS MCP to check if h
 
 1. **Search home-manager**: `mcp__nixos__nix(action="search", source="home-manager", type="programs", query="<tool>")`
 2. **Has `programs.<tool>.enable`?** Use the `programs.*` template
-3. **No module?** Use the `home.packages` fallback
-4. **Create** `modules/home-manager/packages/<tool>/default.nix`
-5. **Add** `(pkg "tool")` to both `hosts/personal.nix` and `hosts/work.nix`
+3. **No module and no config needed?** Skip the module directory — add `"tool"` to the `trivialPkg` list in `lib/hosts.nix` (or in one host file for host-specific tools)
+4. **Otherwise create** `modules/home-manager/packages/<tool>/default.nix` (use the `home.packages` fallback if no module exists)
+5. **Wire it up**: add `"tool"` to `commonPackages` in `lib/hosts.nix` (both hosts), or to `map pkg [ ... ]` in a single host file
 
 ## Template: with home-manager module (preferred)
 

--- a/.claude/skills/nix-darwin/SKILL.md
+++ b/.claude/skills/nix-darwin/SKILL.md
@@ -21,7 +21,7 @@ tool-src = { url = "github:owner/tool"; flake = false; };
 
 ## Host Files
 
-Each host is self-contained at `hosts/<name>.nix`. To add a tool, add `(pkg "tool")` to both files.
+Each host lives at `hosts/<name>.nix` and extends the shared baseline in `lib/hosts.nix` (`commonApps`, `commonPackages`, plus `app`/`pkg`/`trivialPkg` helpers). To add a tool for both hosts, add it to `commonPackages` in `lib/hosts.nix`; for one host only, add it to that host's `map pkg [ ... ]` list.
 
 ## macOS System Defaults
 

--- a/.github/workflows/check.yml
+++ b/.github/workflows/check.yml
@@ -6,11 +6,18 @@ on:
     branches: [main]
 jobs:
   check:
-    runs-on: ubuntu-latest
+    # arm64 macOS runner: the darwinConfigurations are aarch64-darwin, and
+    # `nix flake check` skips them (non-standard output) — the explicit
+    # dry-run builds below are what actually evaluate both hosts.
+    runs-on: macos-latest
     steps:
       - uses: actions/checkout@v5
       - uses: ./.github/actions/setup-devenv
       - name: Check flake
         run: nix flake check --no-build --no-warn-dirty
+      - name: Evaluate host configurations
+        run: |
+          nix build --dry-run --no-warn-dirty .#darwinConfigurations.Castula-KQPN.system
+          nix build --dry-run --no-warn-dirty .#darwinConfigurations.Matts-Personal-Macbook-Air.system
       - name: Run devenv tests
         run: devenv test

--- a/.github/workflows/update.yml
+++ b/.github/workflows/update.yml
@@ -1,7 +1,7 @@
 name: Update Dependencies
 on:
   schedule:
-    - cron: "0 0 * * *" # Daily at midnight UTC
+    - cron: "0 0 * * 1" # Weekly on Monday at midnight UTC
   workflow_dispatch:
 concurrency:
   group: update-dependencies

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -11,7 +11,7 @@ Declarative macOS dotfiles managing system settings, GUI applications, and CLI t
 **Key Features**:
 
 - Modular tool configurations (each tool gets own `default.nix`)
-- Two self-contained host configurations with inline settings
+- Two host configurations sharing a common app/package baseline (`lib/hosts.nix`) with inline per-host settings
 - Independent AI tool configuration (claude-code, opencode, zed) with MCP integration
 - Cross-tool integrations (fzf + bat/eza, git + delta)
 - Reproducible builds via Nix flakes
@@ -33,7 +33,7 @@ format    # Format Nix, YAML, and markdown files (treefmt)
 lint      # Lint Nix files (statix)
 
 # Maintenance
-update    # Update flake and devenv inputs
+update    # Update flake, devenv, and nvfetcher-pinned sources
 clean     # Run garbage collection
 ```
 
@@ -48,6 +48,7 @@ sudo determinate-nixd upgrade
 
 - treefmt (formatting)
 - statix (Nix linting)
+- deadnix (dead code detection)
 - shellcheck (shell script linting)
 - flake-check (validate flake structure)
 
@@ -61,14 +62,22 @@ sudo determinate-nixd upgrade
 .
 ├── flake.nix                    # flake-parts based inputs and outputs
 ├── devenv.nix                   # Development environment & scripts
+├── nvfetcher.toml               # Pinned non-flake sources (prebuilt CLIs, agent-skill repos)
+├── _sources/                    # nvfetcher-generated pins (do not edit by hand)
+├── overlays/
+│   └── default.nix              # Packages built from nvfetcher sources (pup, linear-cli, wacli)
+├── secrets/
+│   ├── secrets.nix              # agenix recipients per secret
+│   └── *.age                    # Encrypted secrets
 ├── .github/workflows/           # GitHub Actions CI
-│   ├── check.yml                # Flake validation and devenv tests
-│   └── update.yml               # Scheduled dependency updates (flake + devenv)
+│   ├── check.yml                # Flake check + host evaluation (macOS runner) + devenv tests
+│   └── update.yml               # Scheduled dependency updates (flake + devenv + nvfetcher)
 ├── lib/
-│   └── mkHost.nix               # Shared darwinSystem builder function
+│   ├── mkHost.nix               # Shared darwinSystem builder function
+│   └── hosts.nix                # Shared app/package lists + helpers (app, pkg, trivialPkg)
 ├── hosts/
-│   ├── personal.nix             # Self-contained personal config (settings + apps + packages)
-│   └── work.nix                 # Self-contained work config (settings + apps + packages)
+│   ├── personal.nix             # Personal host: settings + host-specific apps/packages
+│   └── work.nix                 # Work host: settings + host-specific apps/packages
 └── modules/
     ├── ai/                      # AI tool configuration
     │   ├── default.nix          # Aggregator: imports all base AI modules
@@ -99,7 +108,7 @@ sudo determinate-nixd upgrade
 1. `flake.nix` uses `flake-parts.lib.mkFlake` for modular flake structure
 2. `flake.nix` imports `hosts/personal.nix` and `hosts/work.nix` directly
 3. Each host file defines its own settings (username, email, env vars) inline
-4. Each host file lists its own applications and packages explicitly
+4. Each host file builds its app/package lists from the shared baseline in `lib/hosts.nix` (`commonApps`, `commonPackages`) plus host-specific additions
 5. Host files call `lib/mkHost.nix` which handles all darwinSystem boilerplate
 6. Each module configures a tool using home-manager or `home.packages`
 7. AI tools use `enableMcpIntegration` to connect to shared MCP module
@@ -107,9 +116,12 @@ sudo determinate-nixd upgrade
 **Key Files**:
 
 - `flake.nix` - flake-parts structure with `flake` and `perSystem` outputs, flake inputs
-- `lib/mkHost.nix` - Shared darwinSystem builder (nixpkgs, home-manager, networking)
-- `hosts/personal.nix` - Self-contained personal host (settings, apps, packages)
-- `hosts/work.nix` - Self-contained work host (settings, apps, packages)
+- `lib/mkHost.nix` - Shared darwinSystem builder (nixpkgs, home-manager, agenix, networking)
+- `lib/hosts.nix` - Shared app/package baseline + `app`/`pkg`/`trivialPkg` helpers
+- `hosts/personal.nix` - Personal host (settings + host-specific apps/packages)
+- `hosts/work.nix` - Work host (settings + host-specific apps/packages + work secrets)
+- `overlays/default.nix` - Custom packages built from nvfetcher sources (`pup`, `linear-cli`, `wacli`)
+- `nvfetcher.toml` / `_sources/generated.nix` - Pinned non-flake sources (prebuilt CLIs, agent-skill repos)
 - `devenv.nix` - Scripts (switch, format, lint, update, clean) and git hooks
 - `modules/darwin/system/default.nix` - System defaults importer + meta settings
 - `modules/darwin/system/dock.nix` - Dock, Spaces, Mission Control settings
@@ -121,8 +133,8 @@ sudo determinate-nixd upgrade
 - `modules/ai/tools/{default,catalog,work}.nix` - `ai.tools` catalog: one toggle registers a tool's skills, sources, instructions, and packages
 - `modules/ai/harnesses/claude-code/default.nix` - Claude Code configuration
 - `modules/ai/instructions/INSTRUCTIONS.md` - Global instruction file for all AI harnesses
-- `.github/workflows/check.yml` - CI: flake check + devenv test
-- `.github/workflows/update.yml` - Automated weekly dependency updates (flake + devenv)
+- `.github/workflows/check.yml` - CI: flake check + evaluation of both darwin hosts (macOS runner) + devenv test
+- `.github/workflows/update.yml` - Automated weekly dependency updates (flake + devenv + nvfetcher), auto-merged once checks pass
 
 <!-- END AUTO-MANAGED -->
 
@@ -158,32 +170,43 @@ sudo determinate-nixd upgrade
 
 ### Host Configuration Pattern
 
-Each host is a self-contained file that defines settings, apps, and packages, then calls `mkHost`:
+Shared app/package lists and helpers live in `lib/hosts.nix` (`commonApps`, `commonPackages`, `commonVariables`, plus the `app`/`pkg`/`trivialPkg` helpers). Each host file defines its settings inline, extends the shared baseline with host-specific entries, then calls `mkHost`:
 
 ```nix
 # hosts/personal.nix
 { inputs }:
 let
+  inherit (import ../lib/hosts.nix)
+    app
+    trivialPkg
+    commonApps
+    commonPackages
+    commonVariables
+    ;
+
   settings = {
     username = "mattietea";
+    name = "Matt Thomas";
+    github = "mattietea";
     email = "mattcthomas@me.com";
-    variables = { EDITOR = "zed --wait"; VISUAL = "zed --wait"; };
+    variables = commonVariables;
   };
+
   mkHost = import ../lib/mkHost.nix;
-  app = name: ../modules/home-manager/applications/${name};
-  pkg = name: ../modules/home-manager/packages/${name};
 in
 mkHost {
   inherit inputs settings;
   hostname = "Matts-Personal-Macbook-Air";
-  applications = [ (app "brave") (app "zed") /* ... */ ];
-  packages = [ (pkg "git") (pkg "fzf") /* ... */ ];
+  applications = commonApps ++ map app [ "brave" "spotify" /* ... */ ];
+  packages = commonPackages ++ map trivialPkg [ "wacli" ];
   ai = [
     ../modules/ai
     ../modules/ai/personal.nix
   ];
 }
 ```
+
+Use `trivialPkg "tool"` for tools that need no configuration beyond installing a single nixpkgs attribute — they get no module directory.
 
 ### Cross-Tool Integration
 
@@ -217,12 +240,13 @@ ai = [
 
 **Package sources**:
 
-- claude-code, opencode: External flake input `llm-agents`
+- claude-code: External flake input `claude-code-nix` (own binary cache)
+- opencode: External flake input `llm-agents`
 
 **Model configuration**:
 
 - claude-code: `settings.model` using shorthand names (currently `"opus[1m]"`)
-- opencode: Per-agent models in `oh-my-opencode.json`
+- opencode: Model ids centralized in `modules/ai/harnesses/opencode/models.nix`; per-agent assignments in `oh-my-openagent-base.nix` + per-host overrides
 
 ### External Package Inputs
 
@@ -255,12 +279,10 @@ Key dirs: `$out/libexec/` for internal binaries, `$out/bin/` for user-facing com
 ### Adding New Tools
 
 1. **Check home-manager first**: Run `nix search nixpkgs <tool>` and check home-manager docs
-2. **Create module directory**: `modules/home-manager/packages/<tool>/`
-3. **Add default.nix**: Use standard template (see Conventions)
-4. **Add to host files**: Add `(pkg "tool-name")` to each host that should have it (`hosts/personal.nix`, `hosts/work.nix`)
+2. **No config needed?** Skip the module directory — add `"tool"` to the `trivialPkg` list in `lib/hosts.nix` (both hosts) or in a single host file (one host)
+3. **Needs config?** Create `modules/home-manager/packages/<tool>/default.nix` using the standard template (see Conventions)
+4. **Wire it up**: Add `"tool"` to the `pkg` list in `lib/hosts.nix` `commonPackages` (both hosts), or to `map pkg [ ... ]` in a single host file (one host)
 5. **Test**: Run `devenv shell -- switch`
-
-Note: Each host independently lists its packages — adding to one host does not affect the other.
 
 ### MCP Server Configuration
 

--- a/_sources/generated.json
+++ b/_sources/generated.json
@@ -59,6 +59,21 @@
         },
         "version": "ed02047ae90f25c4c15adb8fd7e224b963f43135"
     },
+    "claude-mem": {
+        "cargoLock": null,
+        "date": null,
+        "extract": null,
+        "name": "claude-mem",
+        "passthru": null,
+        "pinned": false,
+        "src": {
+            "name": null,
+            "sha256": "sha256-BoKqWLfEWSA0rvf6aPbaNd0fFdkUsHZ3r9vS/H8gAas=",
+            "type": "url",
+            "url": "https://registry.npmjs.org/claude-mem/-/claude-mem-13.5.5.tgz"
+        },
+        "version": "13.5.5"
+    },
     "context7-skills": {
         "cargoLock": null,
         "date": "2026-06-13",

--- a/_sources/generated.nix
+++ b/_sources/generated.nix
@@ -48,6 +48,14 @@
     };
     date = "2026-06-12";
   };
+  claude-mem = {
+    pname = "claude-mem";
+    version = "13.5.5";
+    src = fetchurl {
+      url = "https://registry.npmjs.org/claude-mem/-/claude-mem-13.5.5.tgz";
+      sha256 = "sha256-BoKqWLfEWSA0rvf6aPbaNd0fFdkUsHZ3r9vS/H8gAas=";
+    };
+  };
   context7-skills = {
     pname = "context7-skills";
     version = "dec6cf361c58a09968a7f76b3c12c225b5eed39a";

--- a/devenv.nix
+++ b/devenv.nix
@@ -22,8 +22,9 @@
     '';
 
     # nvfetcher reads nvfetcher.toml and regenerates _sources/generated.nix
-    # (pinned version + hash for pup, linear, oh-my-openagent, …). One mechanism
-    # for every non-flake-input dependency — replaces the old update-clis script.
+    # (pinned version + hash for pup, linear, oh-my-openagent, claude-mem, …).
+    # One mechanism for every non-flake-input dependency — replaces the old
+    # update-clis script.
     update.exec = ''
       devenv update;
       nix flake update;

--- a/flake.lock
+++ b/flake.lock
@@ -142,22 +142,6 @@
         "type": "github"
       }
     },
-    "claude-mem": {
-      "flake": false,
-      "locked": {
-        "lastModified": 1781507162,
-        "narHash": "sha256-P6Qvedj0Mw8VToOK2jM7aP6SvJrXWMWy/a6PDK0r170=",
-        "owner": "thedotmack",
-        "repo": "claude-mem",
-        "rev": "b7479f818b09d5e871126027868036d4b6a212a7",
-        "type": "github"
-      },
-      "original": {
-        "owner": "thedotmack",
-        "repo": "claude-mem",
-        "type": "github"
-      }
-    },
     "darwin": {
       "inputs": {
         "nixpkgs": [
@@ -418,7 +402,6 @@
         "agent-skills-nix": "agent-skills-nix",
         "agent-slack": "agent-slack",
         "claude-code-nix": "claude-code-nix",
-        "claude-mem": "claude-mem",
         "darwin": "darwin_2",
         "flake-parts": "flake-parts",
         "home-manager": "home-manager_3",

--- a/flake.nix
+++ b/flake.nix
@@ -21,11 +21,6 @@
     # its own binary cache; overriding nixpkgs would force a source rebuild.
     claude-code-nix.url = "github:sadjow/claude-code-nix";
 
-    claude-mem = {
-      url = "github:thedotmack/claude-mem";
-      flake = false;
-    };
-
     agenix.url = "github:ryantm/agenix";
     agenix.inputs.nixpkgs.follows = "nixpkgs";
 

--- a/modules/ai/harnesses/opencode/models.nix
+++ b/modules/ai/harnesses/opencode/models.nix
@@ -6,5 +6,4 @@
   sonnet = "anthropic/claude-sonnet-4-6";
   haiku = "anthropic/claude-haiku-4-5";
   gpt = "openai/gpt-5.5";
-  codex = "openai/gpt-5.3-codex";
 }

--- a/modules/ai/harnesses/opencode/models.nix
+++ b/modules/ai/harnesses/opencode/models.nix
@@ -1,0 +1,10 @@
+# Single source of truth for model ids used across the opencode configs
+# (oh-my-openagent-base.nix + per-host overrides). Bump a model here and
+# every agent/category referencing it follows.
+{
+  opus = "anthropic/claude-opus-4-8";
+  sonnet = "anthropic/claude-sonnet-4-6";
+  haiku = "anthropic/claude-haiku-4-5";
+  gpt = "openai/gpt-5.5";
+  codex = "openai/gpt-5.3-codex";
+}

--- a/modules/ai/harnesses/opencode/oh-my-openagent-base.nix
+++ b/modules/ai/harnesses/opencode/oh-my-openagent-base.nix
@@ -1,6 +1,25 @@
 # Shared oh-my-openagent configuration
 # Pure data file — imported by opencode-personal and opencode-work
 # Base defaults are Anthropic-only; work host overrides with OpenAI where appropriate
+let
+  models = import ./models.nix;
+
+  # Default profile for heavyweight agents: Opus with extended thinking,
+  # Sonnet for fallback and compaction.
+  opusAgent = {
+    model = models.opus;
+    thinking.type = "enabled";
+    fallback_models = [ models.sonnet ];
+    compaction.model = models.sonnet;
+  };
+
+  # Default profile for heavyweight categories.
+  opusMax = {
+    model = models.opus;
+    variant = "max";
+    thinking.type = "enabled";
+  };
+in
 {
   "$schema" =
     "https://raw.githubusercontent.com/code-yeongyu/oh-my-openagent/dev/assets/oh-my-opencode.schema.json";
@@ -50,7 +69,7 @@
       anthropic = 3;
     };
     modelConcurrency = {
-      "anthropic/claude-opus-4-8" = 2;
+      "${models.opus}" = 2;
     };
   };
 
@@ -88,72 +107,30 @@
 
   agents = {
     # Default opencode agent
-    build = {
-      model = "anthropic/claude-opus-4-8";
-      thinking.type = "enabled";
-      fallback_models = [
-        "anthropic/claude-sonnet-4-6"
-      ];
-      compaction.model = "anthropic/claude-sonnet-4-6";
-    };
+    build = opusAgent;
 
     # Primary orchestrator
-    sisyphus = {
-      model = "anthropic/claude-opus-4-8";
-      thinking.type = "enabled";
-      fallback_models = [
-        "anthropic/claude-sonnet-4-6"
-      ];
-      compaction.model = "anthropic/claude-sonnet-4-6";
-    };
+    sisyphus = opusAgent;
 
-    sisyphus-junior.model = "anthropic/claude-sonnet-4-6";
+    sisyphus-junior.model = models.sonnet;
 
     # Plan execution orchestrator
-    atlas.model = "anthropic/claude-sonnet-4-6";
+    atlas.model = models.sonnet;
 
     # Planning & strategy
-    prometheus = {
-      model = "anthropic/claude-opus-4-8";
-      thinking.type = "enabled";
-      fallback_models = [
-        "anthropic/claude-sonnet-4-6"
-      ];
-      compaction.model = "anthropic/claude-sonnet-4-6";
-    };
+    prometheus = opusAgent;
 
-    metis = {
-      model = "anthropic/claude-opus-4-8";
-      thinking.type = "enabled";
-      fallback_models = [
-        "anthropic/claude-sonnet-4-6"
-      ];
-      compaction.model = "anthropic/claude-sonnet-4-6";
-    };
+    metis = opusAgent;
 
     # Review — host configs may override model + add thinking/reasoningEffort
-    momus = {
-      model = "anthropic/claude-opus-4-8";
-      thinking.type = "enabled";
-      fallback_models = [
-        "anthropic/claude-sonnet-4-6"
-      ];
-      compaction.model = "anthropic/claude-sonnet-4-6";
-    };
+    momus = opusAgent;
 
     # Architecture & debugging — host configs may override model + add thinking/reasoningEffort
-    oracle = {
-      model = "anthropic/claude-opus-4-8";
-      thinking.type = "enabled";
-      fallback_models = [
-        "anthropic/claude-sonnet-4-6"
-      ];
-      compaction.model = "anthropic/claude-sonnet-4-6";
-    };
+    oracle = opusAgent;
 
     # Search & research — read-only, no edit/write permissions
     explore = {
-      model = "anthropic/claude-haiku-4-5";
+      model = models.haiku;
       permission = {
         edit = "deny";
         webfetch = "allow";
@@ -161,7 +138,7 @@
     };
 
     librarian = {
-      model = "anthropic/claude-sonnet-4-6";
+      model = models.sonnet;
       permission = {
         edit = "deny";
         webfetch = "allow";
@@ -169,30 +146,18 @@
     };
 
     # Visual analysis
-    multimodal-looker.model = "anthropic/claude-haiku-4-5";
+    multimodal-looker.model = models.haiku;
   };
 
   # Category defaults (Anthropic); work host overrides deep/ultrabrain/unspecified-high with OpenAI
   categories = {
-    quick.model = "anthropic/claude-haiku-4-5";
-    unspecified-low.model = "anthropic/claude-sonnet-4-6";
-    unspecified-high = {
-      model = "anthropic/claude-opus-4-8";
-      variant = "max";
-      thinking.type = "enabled";
-    };
-    deep = {
-      model = "anthropic/claude-opus-4-8";
-      variant = "max";
-      thinking.type = "enabled";
-    };
-    ultrabrain = {
-      model = "anthropic/claude-opus-4-8";
-      variant = "max";
-      thinking.type = "enabled";
-    };
-    visual-engineering.model = "anthropic/claude-sonnet-4-6";
-    writing.model = "anthropic/claude-sonnet-4-6";
-    artistry.model = "anthropic/claude-sonnet-4-6";
+    quick.model = models.haiku;
+    unspecified-low.model = models.sonnet;
+    unspecified-high = opusMax;
+    deep = opusMax;
+    ultrabrain = opusMax;
+    visual-engineering.model = models.sonnet;
+    writing.model = models.sonnet;
+    artistry.model = models.sonnet;
   };
 }

--- a/modules/ai/harnesses/opencode/personal.nix
+++ b/modules/ai/harnesses/opencode/personal.nix
@@ -2,27 +2,10 @@ _:
 let
   baseConfig = import ./oh-my-openagent-base.nix;
 
-  # Anthropic-only: disable hephaestus, enable extended thinking for oracle/momus
+  # Anthropic-only: disable hephaestus (Codex-backed). The base agents already
+  # run Opus with extended thinking and Sonnet fallback, so no overrides needed.
   config = baseConfig // {
     disabled_agents = [ "hephaestus" ];
-    agents = baseConfig.agents // {
-      oracle = {
-        model = "anthropic/claude-opus-4-8";
-        thinking.type = "enabled";
-        fallback_models = [
-          "anthropic/claude-sonnet-4-6"
-        ];
-        compaction.model = "anthropic/claude-sonnet-4-6";
-      };
-      momus = {
-        model = "anthropic/claude-opus-4-8";
-        thinking.type = "enabled";
-        fallback_models = [
-          "anthropic/claude-sonnet-4-6"
-        ];
-        compaction.model = "anthropic/claude-sonnet-4-6";
-      };
-    };
   };
 in
 {

--- a/modules/ai/harnesses/opencode/personal.nix
+++ b/modules/ai/harnesses/opencode/personal.nix
@@ -2,7 +2,7 @@ _:
 let
   baseConfig = import ./oh-my-openagent-base.nix;
 
-  # Anthropic-only: disable hephaestus (Codex-backed). The base agents already
+  # Anthropic-only: disable hephaestus (OpenAI-backed). The base agents already
   # run Opus with extended thinking and Sonnet fallback, so no overrides needed.
   config = baseConfig // {
     disabled_agents = [ "hephaestus" ];

--- a/modules/ai/harnesses/opencode/work.nix
+++ b/modules/ai/harnesses/opencode/work.nix
@@ -3,7 +3,8 @@ let
   models = import ./models.nix;
   baseConfig = import ./oh-my-openagent-base.nix;
 
-  # Anthropic + OpenAI: GPT for oracle/momus, Codex for deep work, hephaestus enabled
+  # Anthropic + OpenAI: base default agents stay on Opus, GPT for oracle/momus,
+  # hephaestus, and deep work
   config = baseConfig // {
     disabled_agents = [ ];
     agents = baseConfig.agents // {
@@ -28,10 +29,10 @@ let
         ];
         compaction.model = models.sonnet;
       };
-      # Autonomous deep worker — Codex
+      # Autonomous deep worker — GPT
       hephaestus = {
-        model = models.codex;
-        variant = "medium";
+        model = models.gpt;
+        variant = "xhigh";
         fallback_models = [
           models.sonnet
         ];
@@ -51,14 +52,13 @@ let
       };
       modelConcurrency = baseConfig.background_task.modelConcurrency // {
         "${models.gpt}" = 3;
-        "${models.codex}" = 3;
       };
     };
     categories = baseConfig.categories // {
       quick.model = models.sonnet;
       deep = {
-        model = models.codex;
-        variant = "medium";
+        model = models.gpt;
+        variant = "xhigh";
       };
       ultrabrain = {
         model = models.gpt;

--- a/modules/ai/harnesses/opencode/work.nix
+++ b/modules/ai/harnesses/opencode/work.nix
@@ -1,71 +1,72 @@
 _:
 let
+  models = import ./models.nix;
   baseConfig = import ./oh-my-openagent-base.nix;
 
-  # Anthropic + OpenAI: GPT-5.5 for oracle/momus, GPT-5.3-codex for deep work, hephaestus enabled
+  # Anthropic + OpenAI: GPT for oracle/momus, Codex for deep work, hephaestus enabled
   config = baseConfig // {
     disabled_agents = [ ];
     agents = baseConfig.agents // {
-      # Architecture & debugging — GPT-5.4 with high reasoning effort
+      # Architecture & debugging — GPT with high reasoning effort
       oracle = {
-        model = "openai/gpt-5.5";
+        model = models.gpt;
         variant = "high";
         reasoningEffort = "high";
         fallback_models = [
-          "anthropic/claude-opus-4-8"
-          "anthropic/claude-sonnet-4-6"
+          models.opus
+          models.sonnet
         ];
-        compaction.model = "anthropic/claude-sonnet-4-6";
+        compaction.model = models.sonnet;
       };
-      # Review — GPT-5.4 with high reasoning effort
+      # Review — GPT with high reasoning effort
       momus = {
-        model = "openai/gpt-5.5";
+        model = models.gpt;
         variant = "high";
         fallback_models = [
-          "anthropic/claude-opus-4-8"
-          "anthropic/claude-sonnet-4-6"
+          models.opus
+          models.sonnet
         ];
-        compaction.model = "anthropic/claude-sonnet-4-6";
+        compaction.model = models.sonnet;
       };
-      # Autonomous deep worker — GPT-5.3-codex
+      # Autonomous deep worker — Codex
       hephaestus = {
-        model = "openai/gpt-5.3-codex";
+        model = models.codex;
         variant = "medium";
         fallback_models = [
-          "anthropic/claude-sonnet-4-6"
+          models.sonnet
         ];
       };
-      # Fast utility runners — pin to claude-sonnet-4-6 (override base haiku/plugin gpt defaults)
+      # Fast utility runners — pin to Sonnet (override base haiku/plugin gpt defaults)
       explore = baseConfig.agents.explore // {
-        model = "anthropic/claude-sonnet-4-6";
+        model = models.sonnet;
       };
       librarian = baseConfig.agents.librarian // {
-        model = "anthropic/claude-sonnet-4-6";
+        model = models.sonnet;
       };
-      multimodal-looker.model = "anthropic/claude-sonnet-4-6";
+      multimodal-looker.model = models.sonnet;
     };
     background_task = baseConfig.background_task // {
       providerConcurrency = baseConfig.background_task.providerConcurrency // {
         openai = 5;
       };
       modelConcurrency = baseConfig.background_task.modelConcurrency // {
-        "openai/gpt-5.5" = 3;
-        "openai/gpt-5.3-codex" = 3;
+        "${models.gpt}" = 3;
+        "${models.codex}" = 3;
       };
     };
     categories = baseConfig.categories // {
-      quick.model = "anthropic/claude-sonnet-4-6";
+      quick.model = models.sonnet;
       deep = {
-        model = "openai/gpt-5.3-codex";
+        model = models.codex;
         variant = "medium";
       };
       ultrabrain = {
-        model = "openai/gpt-5.5";
+        model = models.gpt;
         variant = "xhigh";
         reasoningEffort = "xhigh";
       };
       unspecified-high = {
-        model = "openai/gpt-5.5";
+        model = models.gpt;
         variant = "high";
       };
     };

--- a/modules/ai/instructions/INSTRUCTIONS.md
+++ b/modules/ai/instructions/INSTRUCTIONS.md
@@ -37,6 +37,35 @@ Never both, never bundled, never narrated.
 
 </important>
 
+<important if="you are starting a coding task, especially a non-trivial or multi-step one">
+
+These guidelines bias toward caution over speed; for trivial tasks, use judgment.
+
+- State your assumptions explicitly. If a request has multiple reasonable interpretations, present them — don't silently pick one. If a simpler approach exists, say so; push back when warranted.
+- Turn the task into verifiable success criteria, then loop until met ("fix the bug" → "write a failing test, then make it pass"; "add validation" → "write tests for invalid inputs, then make them pass").
+- For multi-step work, state a brief plan up front, each step paired with how you'll verify it.
+
+</important>
+
+<important if="you are writing new code or deciding how much to build">
+
+Write the minimum code that solves the stated problem — nothing speculative.
+
+- No features beyond what was asked; no abstractions for single-use code.
+- No configurability or error handling for scenarios that weren't requested or can't occur.
+- If it's 200 lines and could be 50, rewrite it. Ask: would a senior engineer call this overcomplicated?
+
+</important>
+
+<important if="you are editing existing code">
+
+Make surgical changes — every changed line should trace directly to the request.
+
+- Don't "improve" adjacent code, comments, or formatting; don't refactor what isn't broken. Match the existing style even if you'd do it differently.
+- Remove imports/variables/functions that YOUR change orphaned; leave pre-existing dead code alone (mention it, don't delete) unless asked.
+
+</important>
+
 <important if="you need to search the web for information">
 
 Use **Exa** (MCP server) first — higher quality, focused results. Fall back to generic web search only when Exa doesn't cover the topic.

--- a/modules/ai/integrations/claude-mem/default.nix
+++ b/modules/ai/integrations/claude-mem/default.nix
@@ -2,36 +2,36 @@
   config,
   pkgs,
   lib,
-  inputs,
+  sources,
   ...
 }:
 let
-  claudeMemSrc = inputs.claude-mem;
-  claudeMemManifest = builtins.fromJSON (
-    builtins.readFile "${claudeMemSrc}/.codex-plugin/plugin.json"
-  );
-  inherit (claudeMemManifest) version;
+  inherit (sources.claude-mem) version;
 
   # Build-time wrapped marketplace tree.
   #
-  # Pure derivation: copies the claude-mem source then runs wrap-codex-hooks.js
-  # over plugin/hooks/codex-hooks.json (pure JSON in / pure JSON out — no
-  # network, no impurity). The result is a Nix-store path containing the full
-  # claude-mem marketplace with codex hook commands already wrapped to strip
-  # Claude-Code-style output fields ({suppressOutput,status,message}) that
-  # Codex rejects.
+  # claude-mem's published npm tarball is fully self-contained: the CLI
+  # (dist/npx-cli/index.js) and every plugin script (plugin/scripts/*.cjs) are
+  # pre-bundled with their dependencies inlined, so there are no node_modules to
+  # install — plain tarball extraction is the complete, supported install.
   #
-  # Replaces the previous activation-time `wrap_codex_hook_commands` step
-  # which rewrote the hooks JSON in-place inside ~/.claude/plugins/... on
-  # every `switch`.
+  # sources.claude-mem (nvfetcher) tracks npm's dist-tags `latest` and fetches
+  # that exact tarball by its own integrity hash — no FOD output hashes to
+  # maintain, no activation-time network; `update` refreshes the pin.
+  #
+  # Pure derivation: unpacks the tarball, then runs wrap-codex-hooks.js over
+  # plugin/hooks/codex-hooks.json (pure JSON in / pure JSON out) to strip the
+  # Claude-Code-style output fields ({suppressOutput,status,message}) that Codex
+  # rejects. The result is a Nix-store path with the full claude-mem marketplace.
   wrappedMarketplace =
     pkgs.runCommand "claude-mem-codex-marketplace-${version}"
       {
         nativeBuildInputs = [ pkgs.nodejs ];
-        src = claudeMemSrc;
+        src = sources.claude-mem.src;
       }
       ''
-        cp -R $src $out
+        mkdir -p $out
+        tar xzf $src --strip-components=1 -C $out
         chmod -R u+w $out
         ${pkgs.nodejs}/bin/node ${./wrap-codex-hooks.js} \
           "$out/plugin/hooks/codex-hooks.json" \
@@ -62,15 +62,14 @@ in
   # Mirror the build-time wrapped marketplace into ~/.claude/plugins/marketplaces/
   # because:
   #   - Claude Code's plugin loader scans this path
-  #   - bun install + npm install need a writable copy to populate node_modules
+  #   - the runtime expects a writable copy (state, markers)
   #   - modules/ai/mcp/default.nix references the mcp-server.cjs path here
   #
-  # The .nix-source-path marker lets activation skip the copy + reinstall when
-  # the source derivation hasn't changed since the previous generation.
+  # The .nix-source-path marker lets activation skip the copy when the source
+  # derivation hasn't changed since the previous generation.
   #
-  # NOTE: bun install + npm install remain impure (network). Tracked as v2:
-  # FOD-ifying these via a two-FOD pattern (per nixpkgs idiom for npm + bun
-  # plugin trees) requires per-platform output hashes — deferred.
+  # node_modules for both trees are baked into wrappedMarketplace at build
+  # time (see above) — activation only copies, it never touches the network.
   home.activation.installClaudeMemRuntime = lib.hm.dag.entryAfter [ "linkGeneration" ] ''
     version="${version}"
     source="${wrappedMarketplace}"
@@ -85,7 +84,7 @@ in
 
     if [ "$copy_marketplace" -eq 1 ]; then
       mkdir -p "$marketplace"
-      for entry in .agents .codex-plugin plugin package.json package-lock.json openclaw dist LICENSE README.md CHANGELOG.md; do
+      for entry in .agents .codex-plugin plugin package.json openclaw dist LICENSE README.md; do
         if [ -e "$source/$entry" ]; then
           rm -rf "$marketplace/$entry"
           cp -R "$source/$entry" "$marketplace/$entry"
@@ -134,14 +133,7 @@ in
     uv_version="$(${pkgs.uv}/bin/uv --version)"
     export CLAUDE_MEM_UV_VERSION="''${uv_version#uv }"
 
-    if [ "$copy_cache" -eq 1 ] || [ ! -d "$cache/node_modules" ]; then
-      ${pkgs.bun}/bin/bun install --cwd "$cache"
-    fi
     write_marker "$cache"
-
-    if [ "$copy_marketplace" -eq 1 ] || [ ! -d "$marketplace/node_modules" ]; then
-      ${pkgs.nodejs}/bin/npm install --omit=dev --legacy-peer-deps --prefix "$marketplace"
-    fi
     write_marker "$marketplace/plugin"
 
     export CLAUDE_MEM_MARKETPLACE="$marketplace"

--- a/modules/darwin/system/nix.nix
+++ b/modules/darwin/system/nix.nix
@@ -1,6 +1,10 @@
 {
   # Determinate Nix owns /etc/nix/nix.conf; override via nix.custom.conf.
   environment.etc."nix/nix.custom.conf".text = ''
+    # Determinate defaults trusted-users to just `root`, which leaves admin
+    # users untrusted. devenv then can't pass the `system` setting to the
+    # daemon and fails with "Failed to get drvPath from shell derivation".
+    trusted-users = root @admin
     eval-cores = 0
     extra-substituters = https://devenv.cachix.org https://nix-community.cachix.org https://cache.numtide.com
     extra-trusted-public-keys = devenv.cachix.org-1:w1cLUi8dv3hnoSPGAuibQv+f9TZLr6cv/Hm9XgU50cw= nix-community.cachix.org-1:mB9FSh9qf2dCimDSUo8Zy7bkq5CX+/rkCWyvRCYg3Fs= niks3.numtide.com-1:DTx8wZduET09hRmMtKdQDxNNthLQETkc/yaX7M4qK0g=

--- a/nvfetcher.toml
+++ b/nvfetcher.toml
@@ -29,6 +29,16 @@ src.github = "openclaw/wacli"
 src.prefix = "v"
 fetch.url = "https://github.com/openclaw/wacli/releases/download/v$ver/wacli_$ver_darwin_universal.tar.gz"
 
+# claude-mem ships a fully self-contained prebuilt npm tarball: the CLI
+# (dist/npx-cli/index.js) and every plugin script (plugin/scripts/*.cjs) are
+# pre-bundled with dependencies inlined, so there are no node_modules to build.
+# Version tracks npm's dist-tags `latest` (not the GitHub tag) so the fetched
+# tarball always exists — avoids the npm-publish-lags-GitHub-tag race.
+[claude-mem]
+src.webpage = "https://registry.npmjs.org/-/package/claude-mem/dist-tags"
+src.regex = '"latest":"([^"]+)"'
+fetch.url = "https://registry.npmjs.org/claude-mem/-/claude-mem-$ver.tgz"
+
 # Agent-skill sources — repos consumed by agent-skills-nix via path = sources.X.src.
 # Tracked at branch HEAD (these repos cut no releases), pinned by commit + hash.
 [anthropic-skills]

--- a/readme.md
+++ b/readme.md
@@ -48,7 +48,7 @@ format
 # Lint Nix files (uses statix)
 lint
 
-# Update flake inputs
+# Update flake, devenv, and nvfetcher pins
 update
 
 # Clean up old Nix generations

--- a/readme.md
+++ b/readme.md
@@ -5,11 +5,11 @@ Declarative macOS development environment using Nix Flakes, nix-darwin, and home
 ## Key Features
 
 - **Modular architecture**: 40+ tool configurations, each with its own `default.nix`
-- **Multi-host support**: Self-contained personal and work configurations with independent settings
-- **AI-powered development**: Independent configuration for claude-code, opencode, and zed with MCP integration
+- **Multi-host support**: Personal and work hosts share a common app/package baseline (`lib/hosts.nix`) with per-host settings and additions
+- **AI-powered development**: Independent configuration for claude-code, codex, and opencode with MCP integration
 - **Cross-tool integrations**: fzf + bat/eza, git + delta, and more
 - **Reproducible builds**: Everything managed via Nix flakes for complete reproducibility
-- **Automated CI/CD**: GitHub Actions for flake validation, testing, and weekly dependency updates
+- **Automated CI/CD**: GitHub Actions evaluate both host configurations on every PR, plus weekly auto-merged dependency updates
 
 ## Setup
 
@@ -64,7 +64,7 @@ sudo darwin-rebuild switch --flake .
 # Format code
 nix fmt
 
-# Update packages
+# Update packages (flake inputs only — `update` also refreshes devenv + nvfetcher pins)
 nix flake update
 
 # Clean up old generations
@@ -108,16 +108,16 @@ The configuration uses a modular architecture following standard nix-darwin and 
 
 **Entry Point (`flake.nix`):**
 
-- Defines flake inputs (nixpkgs, nix-darwin, home-manager)
-- Creates host configurations by hostname (e.g., `Matts-Work-MacBook-Pro`)
+- Defines flake inputs (nixpkgs, nix-darwin, home-manager, agenix, AI tooling)
+- Creates host configurations by hostname (`Matts-Personal-Macbook-Air`, `Castula-KQPN`)
 - Passes `inputs` directly to host configurations
 
 **Host Configurations (`hosts/personal.nix`, `hosts/work.nix`):**
 
-- Each host is a self-contained file defining settings, applications, and packages
-- Defines `settings` inline: username, email, environment variables
+- Each host defines `settings` inline: username, email, environment variables
+- Shared app/package lists and helpers (`commonApps`, `commonPackages`, `app`, `pkg`, `trivialPkg`) live in `lib/hosts.nix`
+- Hosts extend the shared baseline with host-specific applications and packages
 - Calls `lib/mkHost.nix` builder which handles all darwinSystem boilerplate
-- Lists applications and packages explicitly — hosts are fully independent
 
 **Darwin Modules (`modules/darwin/`):**
 
@@ -143,26 +143,35 @@ The configuration uses a modular architecture following standard nix-darwin and 
 .
 ├── flake.nix                    # flake-parts based inputs and outputs
 ├── devenv.nix                   # Development environment & scripts
+├── nvfetcher.toml               # Pinned non-flake sources (prebuilt CLIs, agent-skill repos)
+├── _sources/                    # nvfetcher-generated pins (do not edit by hand)
+├── overlays/
+│   └── default.nix              # Packages built from nvfetcher sources (pup, linear-cli, wacli)
+├── secrets/
+│   ├── secrets.nix              # agenix recipients per secret
+│   └── *.age                    # Encrypted secrets
 ├── .github/workflows/           # GitHub Actions CI
-│   ├── check.yml                # Flake validation and devenv tests
-│   └── update.yml               # Scheduled dependency updates (flake + devenv)
+│   ├── check.yml                # Flake check + host evaluation (macOS runner) + devenv tests
+│   └── update.yml               # Scheduled dependency updates (flake + devenv + nvfetcher)
 ├── lib/
-│   └── mkHost.nix               # Shared darwinSystem builder function
+│   ├── mkHost.nix               # Shared darwinSystem builder function
+│   └── hosts.nix                # Shared app/package lists + helpers (app, pkg, trivialPkg)
 ├── hosts/
-│   ├── personal.nix             # Self-contained personal config (settings + apps + packages)
-│   └── work.nix                 # Self-contained work config (settings + apps + packages)
+│   ├── personal.nix             # Personal host: settings + host-specific apps/packages
+│   └── work.nix                 # Work host: settings + host-specific apps/packages
 └── modules/
+    ├── ai/                      # AI tooling (harnesses, tools, skills, mcp, plugins, instructions)
     ├── darwin/system/           # macOS system defaults
     │   ├── default.nix          # Importer + meta settings
     │   ├── dock.nix             # Dock, Spaces, Mission Control
     │   ├── finder.nix           # Finder preferences
     │   ├── input.nix            # Keyboard, trackpad, input settings
+    │   ├── nix.nix              # Nix settings + binary caches
     │   └── updates.nix          # Software Update settings
     └── home-manager/
         ├── applications/        # GUI apps (brave, zed, discord, etc.)
         │   └── */default.nix
         └── packages/            # CLI tools (git, fzf, zsh, etc.)
-            ├── mcp/             # Standalone MCP server configuration
             └── */default.nix
 ```
 
@@ -170,7 +179,7 @@ The configuration uses a modular architecture following standard nix-darwin and 
 
 1. `flake.nix` uses `flake-parts.lib.mkFlake` for modular flake structure
 2. `flake.nix` imports `hosts/personal.nix` and `hosts/work.nix` directly
-3. Each host defines settings inline and lists its applications and packages
+3. Each host defines settings inline and extends the shared app/package baseline from `lib/hosts.nix`
 4. Hosts call `lib/mkHost.nix` which handles all darwinSystem boilerplate
 5. Each module configures a tool using home-manager or `home.packages`
 6. AI tools use `enableMcpIntegration` to connect to shared MCP module


### PR DESCRIPTION
## Summary

Four improvements from a full repo review:

### CI now actually gates the auto-merge (`164a551`)
- `nix flake check` skips `darwinConfigurations` (non-standard output), so CI never evaluated either host — yet dependency-update PRs auto-merged on that green check.
- The `check` job now runs on `macos-latest` (arm64) and explicitly dry-run-builds both host system closures, fully evaluating each host without paying for a build.
- Job id stays `check` so existing required-check branch protection keeps matching.
- Update cadence drops daily → weekly, matching the documented schedule and cutting PR churn.

### opencode model ids centralized (`a415164`)
- New `modules/ai/harnesses/opencode/models.nix` is the single source of truth for the five model ids previously scattered across 10 sites in the base config and both host variants.
- Base config gains `opusAgent`/`opusMax` profiles for the repeated Opus+thinking+Sonnet-fallback pattern.
- `personal.nix`'s oracle/momus overrides were byte-identical to the base profile and are dropped — generated JSON unchanged.

### Docs synced to reality (`ee05852`)
- AGENTS.md / readme / nix-darwin + home-manager skills still documented the old self-contained-host pattern; updated for `lib/hosts.nix` (`commonApps`/`commonPackages`/`trivialPkg`).
- Architecture trees now include `lib/hosts.nix`, `overlays/`, `secrets/`, `_sources/`, `nvfetcher.toml`, and `modules/ai/`.
- Fixed phantom hostname (`Matts-Work-MacBook-Pro`) and stale package-source note (claude-code comes from `claude-code-nix`, not `llm-agents`).

### claude-mem: prebuilt npm tarball via nvfetcher (`25731f7`)
- claude-mem's published npm tarball is **fully self-contained** — the CLI (`dist/npx-cli/index.js`) and every plugin script (`plugin/scripts/*.cjs`) are pre-bundled with their dependencies inlined, so there are **no `node_modules` to install**. Plain tarball extraction is the complete, supported install.
- Pinned via an **nvfetcher** entry that tracks npm's `dist-tags.latest` and fetches that exact tarball by its own integrity hash — no FOD output hashes to maintain, no lockfile regeneration, no activation-time network. `update` refreshes the pin like every other prebuilt source.
- Removes the earlier importNpmLock approach entirely: **~3.3k lines** of vendored `package-lock.json` files, `generate-lockfiles.sh`, and the `nodejs` build-dep it required are gone.
- `default.nix`'s `wrappedMarketplace` now unpacks the tarball and runs the same pure `wrap-codex-hooks.js` transform (JSON in / JSON out) to strip the Claude-Code-style output fields Codex rejects.
- Tracking npm's `dist-tags` (rather than the GitHub release tag) guarantees the fetched tarball exists — avoids the npm-publish-lags-tag race.

## Verification

- `nix flake check` passes; both darwin hosts evaluate.
- The real `wrappedMarketplace` derivation builds: the tarball fetches via the pinned hash, unpacks to the expected layout (`plugin/scripts/mcp-server.cjs`, `plugin/hooks/codex-hooks.json`, `.codex-plugin/plugin.json`, `dist/npx-cli/index.js`) with **no `node_modules`**, and the codex hooks are wrapped.

https://claude.ai/code/session_01Wm3EFTeSdgxtBV9f5XKnJF
