### PR TITLE
feat: add mole CLI for both hosts

### DIFF
--- a/_sources/generated.json
+++ b/_sources/generated.json
@@ -189,6 +189,21 @@
         },
         "version": "fc85b919cdb62a668eecea6ea5484aad9da8f655"
     },
+    "mole": {
+        "cargoLock": null,
+        "date": null,
+        "extract": null,
+        "name": "mole",
+        "passthru": null,
+        "pinned": false,
+        "src": {
+            "name": null,
+            "sha256": "sha256-NSssoDwH2Ti/LrSo1ZLqkuJfZFZJn3Qw18hxAvPIPxM=",
+            "type": "url",
+            "url": "https://github.com/tw93/mole/archive/refs/tags/V1.43.1.tar.gz"
+        },
+        "version": "1.43.1"
+    },
     "oh-my-openagent": {
         "cargoLock": null,
         "date": null,

--- a/_sources/generated.nix
+++ b/_sources/generated.nix
@@ -134,6 +134,14 @@
     };
     date = "2026-05-19";
   };
+  mole = {
+    pname = "mole";
+    version = "1.43.1";
+    src = fetchurl {
+      url = "https://github.com/tw93/mole/archive/refs/tags/V1.43.1.tar.gz";
+      sha256 = "sha256-NSssoDwH2Ti/LrSo1ZLqkuJfZFZJn3Qw18hxAvPIPxM=";
+    };
+  };
   oh-my-openagent = {
     pname = "oh-my-openagent";
     version = "4.10.0";

--- a/lib/hosts.nix
+++ b/lib/hosts.nix
@@ -45,6 +45,7 @@ in
     ]
     ++ map trivialPkg [
       "devenv"
+      "mole"
       "nodejs"
     ];
 }

--- a/modules/home-manager/packages/mole/package.nix
+++ b/modules/home-manager/packages/mole/package.nix
@@ -1,0 +1,63 @@
+{
+  lib,
+  buildGoModule,
+  makeWrapper,
+  version,
+  src,
+}:
+buildGoModule {
+  pname = "mole";
+  inherit version src;
+
+  # cmd/analyze and cmd/status are the only Go entrypoints; the rest of the CLI
+  # is bash (mole/mo + lib/ + bin/*.sh) that shells out to these two binaries.
+  subPackages = [
+    "cmd/analyze"
+    "cmd/status"
+  ];
+
+  vendorHash = "sha256-HcCJ3DYj5AXX+E5AD6jxBysCq4TAoIs2I6oVN4dCBxQ=";
+
+  # Release builds are pure-Go (Makefile sets CGO_ENABLED=0); match that so the
+  # gopsutil dependency uses its cgo-free path.
+  env.CGO_ENABLED = 0;
+
+  ldflags = [
+    "-s"
+    "-w"
+  ];
+
+  # The Go tests exercise macOS userland (e.g. BSD `du -I`) that the Nix builder
+  # doesn't provide; upstream runs them on real macOS, so skip them here.
+  doCheck = false;
+
+  nativeBuildInputs = [ makeWrapper ];
+
+  # Assemble the bash CLI next to the freshly built Go binaries. The shell
+  # scripts exec their siblings as bin/analyze-go and bin/status-go (e.g.
+  # bin/analyze.sh: GO_BIN="$SCRIPT_DIR/analyze-go"), and mole resolves lib/ and
+  # bin/ relative to its own path, so the whole tree lives under libexec and
+  # mole/mo become thin wrappers that exec it.
+  postInstall = ''
+    libexec=$out/libexec/mole
+    mkdir -p $libexec
+    cp -r lib bin mole mo $libexec/
+
+    install -Dm755 $out/bin/analyze $libexec/bin/analyze-go
+    install -Dm755 $out/bin/status $libexec/bin/status-go
+    rm $out/bin/analyze $out/bin/status
+
+    patchShebangs $libexec/mole $libexec/mo $libexec/bin
+
+    makeWrapper $libexec/mole $out/bin/mole
+    makeWrapper $libexec/mole $out/bin/mo
+  '';
+
+  meta = {
+    description = "Clean, uninstall, analyze, optimize, and monitor your Mac from the terminal";
+    homepage = "https://github.com/tw93/mole";
+    license = lib.licenses.gpl3Only;
+    platforms = lib.platforms.darwin;
+    mainProgram = "mole";
+  };
+}

--- a/nvfetcher.toml
+++ b/nvfetcher.toml
@@ -29,6 +29,15 @@ src.github = "openclaw/wacli"
 src.prefix = "v"
 fetch.url = "https://github.com/openclaw/wacli/releases/download/v$ver/wacli_$ver_darwin_universal.tar.gz"
 
+# mole is a shell CLI (mole/mo + lib/ + bin/*.sh) plus two Go binaries
+# (cmd/analyze, cmd/status). We build from source via buildGoModule and assemble
+# the shell tree — see modules/home-manager/packages/mole/package.nix. Tags are
+# capitalised (V1.43.1), so prefix = "V" yields the bare $ver.
+[mole]
+src.github = "tw93/mole"
+src.prefix = "V"
+fetch.url = "https://github.com/tw93/mole/archive/refs/tags/V$ver.tar.gz"
+
 # claude-mem ships a fully self-contained prebuilt npm tarball: the CLI
 # (dist/npx-cli/index.js) and every plugin script (plugin/scripts/*.cjs) are
 # pre-bundled with dependencies inlined, so there are no node_modules to build.

--- a/overlays/default.nix
+++ b/overlays/default.nix
@@ -14,4 +14,8 @@ in
   wacli = final.callPackage ../modules/home-manager/packages/wacli/package.nix {
     inherit (sources.wacli) version src;
   };
+
+  mole = final.callPackage ../modules/home-manager/packages/mole/package.nix {
+    inherit (sources.mole) version src;
+  };
 }


### PR DESCRIPTION
## Summary
- Package [tw93/mole](https://github.com/tw93/mole) — a Mac clean/uninstall/analyze/optimize/monitor CLI — from source and install it on **both** the personal and work hosts.

## How it's packaged
mole is a bash CLI (`mole`/`mo` + `lib/` + `bin/*.sh`) that shells out to two Go binaries, so it uses the repo's documented hybrid bash + Go pattern:
- `buildGoModule` builds `cmd/analyze` and `cmd/status` (`CGO_ENABLED=0`, matching upstream's release build)
- the shell tree is assembled under `$out/libexec/mole`, with the Go binaries dropped in as `bin/analyze-go` / `bin/status-go` where the scripts expect them
- `mole` + `mo` are wrapped into `$out/bin`
- `doCheck = false` — the Go tests assume macOS BSD userland (`du -I`) the Nix builder doesn't provide

Source is pinned via nvfetcher (`V1.43.1`) and exposed through the overlay as `pkgs.mole`; wired into `commonPackages` so both hosts get it.

## Test plan
- [x] `nix flake check` — both `Matts-Personal-Macbook-Air` and `Castula-KQPN` evaluate
- [x] `pkgs.mole` builds on both hosts (identical store path)
- [x] `mole`/`mo --version` → `1.43.1`; `analyze-go`/`status-go` execute and are codesigned (arm64)
- [x] treefmt, statix, deadnix clean
- [ ] `switch` applied on each host

## Note
mole's self-update (`mo update`) and Homebrew detection won't work from the read-only Nix store — bump via `nvfetcher` + `switch` instead.