### PR TITLE
fix: restore app launching (copyApps) + freshen flake inputs

### DIFF
--- a/flake.lock
+++ b/flake.lock
@@ -129,11 +129,11 @@
         "nixpkgs": "nixpkgs"
       },
       "locked": {
-        "lastModified": 1781560224,
-        "narHash": "sha256-+4c90gzrBDnPtTs2B2M5xcDC5h0lN7lOg7dmxlPWteA=",
+        "lastModified": 1781833989,
+        "narHash": "sha256-zLuv4n6C5ceFaLwYKV2uh8zK7Z6fFXx7FD398pi2GVU=",
         "owner": "sadjow",
         "repo": "claude-code-nix",
-        "rev": "c411244f49e20360939644a2228f6cb0789f97f6",
+        "rev": "a94e5e841e4992e8e173aba973cb9c41ec575bb8",
         "type": "github"
       },
       "original": {
@@ -171,11 +171,11 @@
         ]
       },
       "locked": {
-        "lastModified": 1781190061,
-        "narHash": "sha256-QRMpLbsmlciMGv4yx75FUoIl54K02JbIX1tgdPHPw1s=",
+        "lastModified": 1781772065,
+        "narHash": "sha256-xIbRSwDB1GBAUsWsQZUjudGfAGQt3BOpsWaO/ugVa4w=",
         "owner": "nix-darwin",
         "repo": "nix-darwin",
-        "rev": "f2b3fdb347f91dfd344ad196666a0b0fe8aad05c",
+        "rev": "adda04f0bf4819575b1978c2f8d78401b3c2be12",
         "type": "github"
       },
       "original": {
@@ -335,11 +335,11 @@
         "treefmt-nix": "treefmt-nix"
       },
       "locked": {
-        "lastModified": 1781573957,
-        "narHash": "sha256-d4IidRcANvwBETwlwe1bNXjFVcczq/Q/8EJvsIYh6Z4=",
+        "lastModified": 1781935030,
+        "narHash": "sha256-VbghtmBX09cL/JIm5fXSzHnI2tFE8lorxe9Fx/hE6yk=",
         "owner": "numtide",
         "repo": "llm-agents.nix",
-        "rev": "ce2ae35ca1db428948ed9dac4b935bc4d7923ca6",
+        "rev": "6d65e7002dd5fe407af6d989ea49f9e89619d4db",
         "type": "github"
       },
       "original": {
@@ -350,11 +350,11 @@
     },
     "nixpkgs": {
       "locked": {
-        "lastModified": 1781454065,
-        "narHash": "sha256-d2xfDjnfRuf/xYGdu9VVRHiav/2w5hDL/5cw2TuVAXw=",
+        "lastModified": 1781607440,
+        "narHash": "sha256-rxO+uc/KFbSJp+pgyXRuAX6QlG9hJdnt0BXpEQRXY+U=",
         "owner": "NixOS",
         "repo": "nixpkgs",
-        "rev": "9eac87a12312b8f60dd52e1c6e1a265f6fc7f5fc",
+        "rev": "3e41b24abd260e8f71dbe2f5737d24122f972158",
         "type": "github"
       },
       "original": {
@@ -366,11 +366,11 @@
     },
     "nixpkgs_2": {
       "locked": {
-        "lastModified": 1781454065,
-        "narHash": "sha256-d2xfDjnfRuf/xYGdu9VVRHiav/2w5hDL/5cw2TuVAXw=",
+        "lastModified": 1781607440,
+        "narHash": "sha256-rxO+uc/KFbSJp+pgyXRuAX6QlG9hJdnt0BXpEQRXY+U=",
         "owner": "NixOS",
         "repo": "nixpkgs",
-        "rev": "9eac87a12312b8f60dd52e1c6e1a265f6fc7f5fc",
+        "rev": "3e41b24abd260e8f71dbe2f5737d24122f972158",
         "type": "github"
       },
       "original": {
@@ -382,11 +382,11 @@
     },
     "nixpkgs_3": {
       "locked": {
-        "lastModified": 1781236690,
-        "narHash": "sha256-ox8n9kxKUnMP2Q9sq2NWul2lOUzNFwlvlCVtH4hP0hY=",
+        "lastModified": 1781472460,
+        "narHash": "sha256-dqwpb1o0xIwb1rv3PPbpY7RBm8heFiOLAubszNLBefc=",
         "owner": "NixOS",
         "repo": "nixpkgs",
-        "rev": "b5e61da309336bdba24f964dce712a5ab8e0092e",
+        "rev": "8c14fa3ccacddaec887134e523083b63c8ea57ac",
         "type": "github"
       },
       "original": {
@@ -413,11 +413,11 @@
     "superpowers": {
       "flake": false,
       "locked": {
-        "lastModified": 1781551102,
-        "narHash": "sha256-sKww11UOOHzZWxcHCprnF2+0pnuuGWIJpDoU7pxzRC4=",
+        "lastModified": 1781822662,
+        "narHash": "sha256-+lT2a/qq0SF4k0PgnEDKiuidVlZX2p0vEso4d/5T1os=",
         "owner": "obra",
         "repo": "superpowers",
-        "rev": "8cf39006140a743dce31ba4046fceab90cc214e6",
+        "rev": "896224c4b1879920ab573417e68fd51d2ccc9072",
         "type": "github"
       },
       "original": {

--- a/lib/mkHost.nix
+++ b/lib/mkHost.nix
@@ -70,13 +70,12 @@ inputs.darwin.lib.darwinSystem {
         ++ packages
         ++ ai;
         users.${settings.username} = {
-          # Symlink GUI apps into ~/Applications/Home Manager Apps instead of
-          # copying them (copyApps is the default at stateVersion >= 25.11).
-          # Linking is instant and uses ~no disk; copyApps rsync'd ~13GB of app
-          # bundles on every switch. Trade-off: symlinked .apps aren't indexed by
-          # Spotlight/Launchpad and some may not launch from the read-only store.
-          targets.darwin.copyApps.enable = false;
-          targets.darwin.linkApps.enable = true;
+          # Copy GUI apps into ~/Applications/Home Manager Apps. linkApps
+          # (symlinks into the read-only store) is faster but macOS won't launch
+          # symlinked .apps, so copyApps is required. The switch script no longer
+          # rm -rf's this folder, so rsync copies incrementally (only changed
+          # apps) instead of re-copying everything every time.
+          targets.darwin.copyApps.enable = true;
           manual = {
             json.enable = false;
             html.enable = false;


### PR DESCRIPTION
## Why
`main` currently ships `targets.darwin.linkApps` (merged via #168), which symlinks `.app`s into the read-only Nix store. **macOS won't launch those** — the Dock shows alias badges and apps don't open. This restores `copyApps`.

While here, freshen the flake inputs (the lock had drifted; root inputs were already on 26.05 but a few days behind).

## Changes
- **`lib/mkHost.nix`**: `copyApps.enable = true` (was `linkApps`). The `rm -rf` removal from #168 stays, so copy is still incremental/fast.
- **`flake.lock`** (`nix flake update`): all 26.05-paired —
  - `darwin` → `nix-darwin/nix-darwin@adda04f` (2026-06-18, `nix-darwin-26.05`)
  - `home-manager` → `@8355f0a` (2026-06-13, `release-26.05`)
  - `nixpkgs` → latest `nixpkgs-26.05-darwin`

## Test plan
- [x] `nix flake check` — both hosts evaluate
- [x] inputs paired on 26.05 (passes nix-darwin's branch-match assertion)
- [x] treefmt / statix / deadnix clean
- [ ] `switch`: apps copied (not symlinked) and launch normally

## After merge — one-time on each machine
```bash
rm ~/Applications/Home\ Manager\ Apps   # remove the broken symlink
git checkout main && git pull
devenv shell -- switch                   # re-copies real .app bundles
```