### PR TITLE
chore: package agent-slack via nvfetcher, bump to v0.9.3

### DIFF
--- a/_sources/generated.json
+++ b/_sources/generated.json
@@ -19,6 +19,41 @@
         },
         "version": "4572acf0d71c0086009206c9c1e2136fc54ec9e5"
     },
+    "agent-slack": {
+        "cargoLock": null,
+        "date": null,
+        "extract": null,
+        "name": "agent-slack",
+        "passthru": null,
+        "pinned": false,
+        "src": {
+            "name": null,
+            "sha256": "sha256-ISvecKk6btX0kRyOc4jLH1a1HuCFABa8K9VbdByiBZY=",
+            "type": "url",
+            "url": "https://github.com/stablyai/agent-slack/releases/download/v0.9.3/agent-slack-darwin-arm64"
+        },
+        "version": "0.9.3"
+    },
+    "agent-slack-skills": {
+        "cargoLock": null,
+        "date": "2026-06-04",
+        "extract": null,
+        "name": "agent-slack-skills",
+        "passthru": null,
+        "pinned": false,
+        "src": {
+            "deepClone": false,
+            "fetchSubmodules": false,
+            "leaveDotGit": false,
+            "name": null,
+            "rev": "6775fa878dfe7d38ca15899c765a2e19c9718a39",
+            "sha256": "sha256-nxpBZisxvnXD0xEoC9Vr2T6sthLIDW6NoTp5tEbM+I4=",
+            "sparseCheckout": [],
+            "type": "git",
+            "url": "https://github.com/stablyai/agent-slack"
+        },
+        "version": "6775fa878dfe7d38ca15899c765a2e19c9718a39"
+    },
     "anthropic-skills": {
         "cargoLock": null,
         "date": "2026-06-09",

--- a/_sources/generated.nix
+++ b/_sources/generated.nix
@@ -20,6 +20,28 @@
     };
     date = "2026-06-20";
   };
+  agent-slack = {
+    pname = "agent-slack";
+    version = "0.9.3";
+    src = fetchurl {
+      url = "https://github.com/stablyai/agent-slack/releases/download/v0.9.3/agent-slack-darwin-arm64";
+      sha256 = "sha256-ISvecKk6btX0kRyOc4jLH1a1HuCFABa8K9VbdByiBZY=";
+    };
+  };
+  agent-slack-skills = {
+    pname = "agent-slack-skills";
+    version = "6775fa878dfe7d38ca15899c765a2e19c9718a39";
+    src = fetchgit {
+      url = "https://github.com/stablyai/agent-slack";
+      rev = "6775fa878dfe7d38ca15899c765a2e19c9718a39";
+      fetchSubmodules = false;
+      deepClone = false;
+      leaveDotGit = false;
+      sparseCheckout = [ ];
+      sha256 = "sha256-nxpBZisxvnXD0xEoC9Vr2T6sthLIDW6NoTp5tEbM+I4=";
+    };
+    date = "2026-06-04";
+  };
   anthropic-skills = {
     pname = "anthropic-skills";
     version = "57546260929473d4e0d1c1bb75297be2fdfa1949";

--- a/flake.lock
+++ b/flake.lock
@@ -44,27 +44,6 @@
         "type": "github"
       }
     },
-    "agent-slack": {
-      "inputs": {
-        "flake-utils": "flake-utils",
-        "nixpkgs": [
-          "nixpkgs"
-        ]
-      },
-      "locked": {
-        "lastModified": 1780617934,
-        "narHash": "sha256-nxpBZisxvnXD0xEoC9Vr2T6sthLIDW6NoTp5tEbM+I4=",
-        "owner": "stablyai",
-        "repo": "agent-slack",
-        "rev": "6775fa878dfe7d38ca15899c765a2e19c9718a39",
-        "type": "github"
-      },
-      "original": {
-        "owner": "stablyai",
-        "repo": "agent-slack",
-        "type": "github"
-      }
-    },
     "blueprint": {
       "inputs": {
         "nixpkgs": [
@@ -125,7 +104,7 @@
     },
     "claude-code-nix": {
       "inputs": {
-        "flake-utils": "flake-utils_2",
+        "flake-utils": "flake-utils",
         "nixpkgs": "nixpkgs"
       },
       "locked": {
@@ -244,24 +223,6 @@
         "type": "github"
       }
     },
-    "flake-utils_2": {
-      "inputs": {
-        "systems": "systems_3"
-      },
-      "locked": {
-        "lastModified": 1731533236,
-        "narHash": "sha256-l0KFg5HjrsfsO/JpG+r7fRrqm12kzFHyUHqHCVpMMbI=",
-        "owner": "numtide",
-        "repo": "flake-utils",
-        "rev": "11707dc2f618dd54ca8739b309ec4fc024de578b",
-        "type": "github"
-      },
-      "original": {
-        "owner": "numtide",
-        "repo": "flake-utils",
-        "type": "github"
-      }
-    },
     "home-manager": {
       "inputs": {
         "nixpkgs": [
@@ -331,7 +292,7 @@
         "bun2nix": "bun2nix",
         "flake-parts": "flake-parts_2",
         "nixpkgs": "nixpkgs_2",
-        "systems": "systems_4",
+        "systems": "systems_3",
         "treefmt-nix": "treefmt-nix"
       },
       "locked": {
@@ -400,7 +361,6 @@
       "inputs": {
         "agenix": "agenix",
         "agent-skills-nix": "agent-skills-nix",
-        "agent-slack": "agent-slack",
         "claude-code-nix": "claude-code-nix",
         "darwin": "darwin_2",
         "flake-parts": "flake-parts",
@@ -457,21 +417,6 @@
       }
     },
     "systems_3": {
-      "locked": {
-        "lastModified": 1681028828,
-        "narHash": "sha256-Vy1rq5AaRuLzOxct8nz4T6wlgyUR7zLU309k9mBC768=",
-        "owner": "nix-systems",
-        "repo": "default",
-        "rev": "da67096a3b9bf56a91d16901293e51ba5b49a27e",
-        "type": "github"
-      },
-      "original": {
-        "owner": "nix-systems",
-        "repo": "default",
-        "type": "github"
-      }
-    },
-    "systems_4": {
       "locked": {
         "lastModified": 1681028828,
         "narHash": "sha256-Vy1rq5AaRuLzOxct8nz4T6wlgyUR7zLU309k9mBC768=",

--- a/flake.nix
+++ b/flake.nix
@@ -27,9 +27,6 @@
     agent-skills-nix.url = "github:Kyure-A/agent-skills-nix";
     agent-skills-nix.inputs.nixpkgs.follows = "nixpkgs";
 
-    agent-slack.url = "github:stablyai/agent-slack";
-    agent-slack.inputs.nixpkgs.follows = "nixpkgs";
-
     superpowers = {
       url = "github:obra/superpowers";
       flake = false;

--- a/modules/ai/tools/work.nix
+++ b/modules/ai/tools/work.nix
@@ -1,5 +1,4 @@
 {
-  inputs,
   pkgs,
   sources,
   ...
@@ -62,11 +61,11 @@
     agent-slack = {
       enable = true;
       sources.agent-slack = {
-        input = "agent-slack";
+        path = sources.agent-slack-skills.src;
         subdir = "skills";
       };
       skills = [ "agent-slack" ];
-      packages = [ inputs.agent-slack.packages.${pkgs.stdenv.hostPlatform.system}.default ];
+      packages = [ pkgs.agent-slack ];
     };
   };
 }

--- a/modules/home-manager/packages/agent-slack/package.nix
+++ b/modules/home-manager/packages/agent-slack/package.nix
@@ -1,0 +1,26 @@
+{
+  lib,
+  stdenvNoCC,
+  version,
+  src,
+}:
+stdenvNoCC.mkDerivation {
+  pname = "agent-slack";
+  inherit version src;
+
+  dontUnpack = true;
+
+  installPhase = ''
+    runHook preInstall
+    install -Dm755 "$src" "$out/bin/agent-slack"
+    runHook postInstall
+  '';
+
+  meta = {
+    description = "Slack automation CLI for AI agents";
+    homepage = "https://github.com/stablyai/agent-slack";
+    license = lib.licenses.mit;
+    mainProgram = "agent-slack";
+    sourceProvenance = [ lib.sourceTypes.binaryNativeCode ];
+  };
+}

--- a/nvfetcher.toml
+++ b/nvfetcher.toml
@@ -38,6 +38,14 @@ src.github = "tw93/mole"
 src.prefix = "V"
 fetch.url = "https://github.com/tw93/mole/archive/refs/tags/V$ver.tar.gz"
 
+# agent-slack ships a raw prebuilt binary per platform as a release asset
+# (no archive). Tracks the latest GitHub release so update.yml bumps it
+# automatically — upstream's in-repo nix/sources.json lags their releases.
+[agent-slack]
+src.github = "stablyai/agent-slack"
+src.prefix = "v"
+fetch.url = "https://github.com/stablyai/agent-slack/releases/download/v$ver/agent-slack-darwin-arm64"
+
 # claude-mem ships a fully self-contained prebuilt npm tarball: the CLI
 # (dist/npx-cli/index.js) and every plugin script (plugin/scripts/*.cjs) are
 # pre-bundled with dependencies inlined, so there are no node_modules to build.
@@ -119,3 +127,8 @@ fetch.git = "https://github.com/humanlayer/skills"
 src.git = "https://github.com/stablyai/orca"
 src.branch = "main"
 fetch.git = "https://github.com/stablyai/orca"
+
+[agent-slack-skills]
+src.git = "https://github.com/stablyai/agent-slack"
+src.branch = "main"
+fetch.git = "https://github.com/stablyai/agent-slack"

--- a/overlays/default.nix
+++ b/overlays/default.nix
@@ -18,4 +18,8 @@ in
   mole = final.callPackage ../modules/home-manager/packages/mole/package.nix {
     inherit (sources.mole) version src;
   };
+
+  agent-slack = final.callPackage ../modules/home-manager/packages/agent-slack/package.nix {
+    inherit (sources.agent-slack) version src;
+  };
 }


### PR DESCRIPTION
## Problem

The running `agent-slack` was stuck at **0.5.2** despite the flake input pointing at the latest `main`. Root cause: agent-slack's Nix packaging installs a prebuilt release binary whose version + hashes live in the upstream repo's `nix/sources.json`, and **that file on `main` is frozen at v0.5.2** — well behind their published releases (v0.9.3). No flake update could move past it.

## Fix

Switch agent-slack to this repo's existing nvfetcher pattern (same as `pup` / `linear` / `wacli`):

- `[agent-slack]` — tracks the latest GitHub **release**, fetches the `darwin-arm64` binary asset
- `[agent-slack-skills]` — git source for the `skills/` subdir
- new `modules/home-manager/packages/agent-slack/package.nix` installs the raw binary
- exposed via `overlays/default.nix`; `work.nix` now uses `pkgs.agent-slack` + `sources.agent-slack-skills.src`
- removes the `agent-slack` flake input (and its transitive `flake-utils`) from `flake.nix` / `flake.lock`

Net effect: bumps to **v0.9.3**, and the weekly `update.yml` (which runs `nvfetcher`) will auto-track future releases instead of being frozen behind upstream's stale in-repo pin.

## Verification

- Work host (`Castula-KQPN`) system builds
- Built closure ships `agent-slack-0.9.3`; binary reports `0.9.3`
- treefmt / statix / deadnix / flake-check hooks pass