### PR TITLE
fix: localHostName drift, mole vendorHash, declarative voice

### DIFF
--- a/hosts/personal.nix
+++ b/hosts/personal.nix
@@ -21,6 +21,7 @@ in
 mkHost {
   inherit inputs settings;
   hostname = "Matts-Personal-Macbook-Air";
+  computerName = "Matt's Personal Macbook Air";
 
   applications =
     commonApps

--- a/lib/mkHost.nix
+++ b/lib/mkHost.nix
@@ -2,6 +2,7 @@
   inputs,
   settings,
   hostname,
+  computerName ? null,
   system ? "aarch64-darwin",
   applications ? [ ],
   packages ? [ ],
@@ -103,7 +104,13 @@ inputs.darwin.lib.darwinSystem {
         };
       };
     }
-    { networking.hostName = hostname; }
+    {
+      networking = {
+        hostName = hostname;
+        localHostName = hostname;
+        computerName = if computerName == null then hostname else computerName;
+      };
+    }
   ]
   ++ darwinModules;
 }

--- a/modules/ai/harnesses/claude-code/default.nix
+++ b/modules/ai/harnesses/claude-code/default.nix
@@ -23,6 +23,12 @@
       prStatusFooterEnabled = true;
       editorMode = "normal";
 
+      # Voice
+      voice = {
+        enabled = true;
+        mode = "tap";
+      };
+
       # Features
       alwaysThinkingEnabled = true;
       autoCompactEnabled = true;

--- a/modules/home-manager/packages/mole/package.nix
+++ b/modules/home-manager/packages/mole/package.nix
@@ -16,7 +16,7 @@ buildGoModule {
     "cmd/status"
   ];
 
-  vendorHash = "sha256-HcCJ3DYj5AXX+E5AD6jxBysCq4TAoIs2I6oVN4dCBxQ=";
+  vendorHash = "sha256-hLFlAy4AE1eNOxd4d75Mbo3ZKlwvNK7QV2DNVPd7NHc=";
 
   # Release builds are pure-Go (Makefile sets CGO_ENABLED=0); match that so the
   # gopsutil dependency uses its cgo-free path.


### PR DESCRIPTION
## Summary

Three related fixes surfaced while getting `switch` working again on the personal host.

- **fix: manage `localHostName` and `computerName` declaratively** — macOS silently renamed `LocalHostName` to `Matts-Personal-Macbook-Air-2` on an mDNS name conflict, which broke `darwin-rebuild`'s hostname-based config lookup (`switch` failed to find the darwin configuration). `mkHost` only set `networking.hostName`; it now also sets `localHostName` and `computerName`, so `switch` reasserts all three every run and this can't recur.
- **fix: update mole `vendorHash` for 1.46.0 bump** — the auto-update bumped mole to 1.46.0 and its Go deps changed, leaving a stale `vendorHash` that failed the build (a separate pre-existing blocker for `switch`).
- **feat: enable Claude Code voice dictation (tap mode)** — `/voice` can't persist because `~/.claude/settings.json` is a read-only nix-store symlink, so voice is enabled declaratively in the claude-code settings instead.

## Test plan

- [x] `nix build .#darwinConfigurations.Matts-Personal-Macbook-Air.system` succeeds
- [x] Rendered `settings.json` contains `voice = {"enabled":true,"mode":"tap"}`
- [x] treefmt / statix / deadnix / flake-check pre-commit hooks pass
- [ ] `sudo darwin-rebuild switch` applies cleanly and `LocalHostName` resets from `-2`