### PR TITLE
feat: add omp CLI package

### DIFF
--- a/_sources/generated.json
+++ b/_sources/generated.json
@@ -254,6 +254,21 @@
         },
         "version": "4.19.0"
     },
+    "omp": {
+        "cargoLock": null,
+        "date": null,
+        "extract": null,
+        "name": "omp",
+        "passthru": null,
+        "pinned": false,
+        "src": {
+            "name": null,
+            "sha256": "sha256-wNQ8R7lp77Z/oYT3edGDu1JBHphnK3afsOcdUdWe7Wg=",
+            "type": "url",
+            "url": "https://github.com/can1357/oh-my-pi/releases/download/v17.0.5/omp-darwin-arm64"
+        },
+        "version": "17.0.5"
+    },
     "orca-skills": {
         "cargoLock": null,
         "date": "2026-07-19",

--- a/_sources/generated.nix
+++ b/_sources/generated.nix
@@ -172,6 +172,14 @@
       sha256 = "sha256-3Rf9diLBdGZdSErLizUPhmq5OEHbyD2rwFKC67URNXs=";
     };
   };
+  omp = {
+    pname = "omp";
+    version = "17.0.5";
+    src = fetchurl {
+      url = "https://github.com/can1357/oh-my-pi/releases/download/v17.0.5/omp-darwin-arm64";
+      sha256 = "sha256-wNQ8R7lp77Z/oYT3edGDu1JBHphnK3afsOcdUdWe7Wg=";
+    };
+  };
   orca-skills = {
     pname = "orca-skills";
     version = "c0f0810dd9c89c57e2130e5d7b5adcbef883845c";

--- a/lib/hosts.nix
+++ b/lib/hosts.nix
@@ -46,5 +46,6 @@ in
       "devenv"
       "mole"
       "nodejs"
+      "omp"
     ];
 }

--- a/modules/home-manager/packages/omp/package.nix
+++ b/modules/home-manager/packages/omp/package.nix
@@ -1,0 +1,26 @@
+{
+  lib,
+  stdenvNoCC,
+  version,
+  src,
+}:
+stdenvNoCC.mkDerivation {
+  pname = "omp";
+  inherit version src;
+
+  dontUnpack = true;
+
+  installPhase = ''
+    runHook preInstall
+    install -Dm755 "$src" "$out/bin/omp"
+    runHook postInstall
+  '';
+
+  meta = {
+    description = "oh my pi — a coding agent with the IDE wired in";
+    homepage = "https://omp.sh";
+    license = lib.licenses.mit;
+    mainProgram = "omp";
+    sourceProvenance = [ lib.sourceTypes.binaryNativeCode ];
+  };
+}

--- a/nvfetcher.toml
+++ b/nvfetcher.toml
@@ -46,6 +46,13 @@ src.github = "stablyai/agent-slack"
 src.prefix = "v"
 fetch.url = "https://github.com/stablyai/agent-slack/releases/download/v$ver/agent-slack-darwin-arm64"
 
+# omp (oh-my-pi, omp.sh) ships a raw prebuilt binary per platform as a
+# release asset (no archive), same shape as agent-slack.
+[omp]
+src.github = "can1357/oh-my-pi"
+src.prefix = "v"
+fetch.url = "https://github.com/can1357/oh-my-pi/releases/download/v$ver/omp-darwin-arm64"
+
 # claude-mem ships a fully self-contained prebuilt npm tarball: the CLI
 # (dist/npx-cli/index.js) and every plugin script (plugin/scripts/*.cjs) are
 # pre-bundled with dependencies inlined, so there are no node_modules to build.

--- a/overlays/default.nix
+++ b/overlays/default.nix
@@ -23,6 +23,10 @@ in
     inherit (sources.agent-slack) version src;
   };
 
+  omp = final.callPackage ../modules/home-manager/packages/omp/package.nix {
+    inherit (sources.omp) version src;
+  };
+
   zed-editor = final.callPackage ../modules/home-manager/applications/zed/package.nix {
     inherit (sources.zed) version src;
   };


### PR DESCRIPTION
Adds the OMP Coding Agent CLI as a common package on all hosts.

- Pin omp source (v17.0.5) via nvfetcher
- Package derivation at `modules/home-manager/packages/omp/package.nix`
- Wired into overlays and `lib/hosts.nix` common packages