### PR TITLE
Update dependencies

### DIFF
--- a/_sources/generated.json
+++ b/_sources/generated.json
@@ -1,7 +1,7 @@
 {
     "agent-browser-skills": {
         "cargoLock": null,
-        "date": "2026-08-05",
+        "date": "2026-08-10",
         "extract": null,
         "name": "agent-browser-skills",
         "passthru": null,
@@ -11,13 +11,13 @@
             "fetchSubmodules": false,
             "leaveDotGit": false,
             "name": null,
-            "rev": "acbc22bdc5d4f6c5a88d97d4a4745d3c5eb0591f",
-            "sha256": "sha256-GtN5IvyBSvOJ76lB5LSYNGr1m9MhpBDNASG/8iH3tVM=",
+            "rev": "861e76ddf48ea48f4ce5fe0e79dc725b084d0e8b",
+            "sha256": "sha256-zsXcEBAdEMdtFX63idphwYerpdgYBMskJ7utuKiHqTI=",
             "sparseCheckout": [],
             "type": "git",
             "url": "https://github.com/vercel-labs/agent-browser"
         },
-        "version": "acbc22bdc5d4f6c5a88d97d4a4745d3c5eb0591f"
+        "version": "861e76ddf48ea48f4ce5fe0e79dc725b084d0e8b"
     },
     "agent-slack": {
         "cargoLock": null,
@@ -103,11 +103,11 @@
         "pinned": false,
         "src": {
             "name": null,
-            "sha256": "sha256-37uDw1ySeT/zArYzAIEhu5fihv+ZJvq2hjFl2J+SFR0=",
+            "sha256": "sha256-bYkIvYqFmsZg7Nf2kiChX+4Y+xDVHwJr+FzLk58Z0E0=",
             "type": "url",
-            "url": "https://registry.npmjs.org/claude-mem/-/claude-mem-13.14.0.tgz"
+            "url": "https://registry.npmjs.org/claude-mem/-/claude-mem-13.15.0.tgz"
         },
-        "version": "13.14.0"
+        "version": "13.15.0"
     },
     "context7-skills": {
         "cargoLock": null,
@@ -301,13 +301,13 @@
             "fetchSubmodules": false,
             "leaveDotGit": false,
             "name": null,
-            "rev": "56b6d845e013f7e94d3a031ad7e22b9de0821056",
-            "sha256": "sha256-emEEskprW0IWM8Lj445q5vSbA1HaNVekq+sJXErQEZQ=",
+            "rev": "8da362919e4a79122b6655c778d8808c690ec47e",
+            "sha256": "sha256-uuaMHpDtIRsW+xx1NAQ7ypoBxwSlSw4xRP8Ig8eMFJc=",
             "sparseCheckout": [],
             "type": "git",
             "url": "https://github.com/stablyai/orca"
         },
-        "version": "56b6d845e013f7e94d3a031ad7e22b9de0821056"
+        "version": "8da362919e4a79122b6655c778d8808c690ec47e"
     },
     "playwriter-skills": {
         "cargoLock": null,
@@ -346,7 +346,7 @@
     },
     "pup-skills": {
         "cargoLock": null,
-        "date": "2026-08-07",
+        "date": "2026-08-10",
         "extract": null,
         "name": "pup-skills",
         "passthru": null,
@@ -356,17 +356,17 @@
             "fetchSubmodules": false,
             "leaveDotGit": false,
             "name": null,
-            "rev": "5c47c9c49a72417984a9db2540d2dbc5a0150b69",
-            "sha256": "sha256-PSfWundBHpT0fgkeSB0bB2QANSvtWQy+HbcSfFirBpc=",
+            "rev": "28dd51b42f1cfb8b94f3e7f1661e77c67e9d5907",
+            "sha256": "sha256-rl51fqtaXDoa9l91WsvTbVWBOz/YtCopvcHSUaEtzb4=",
             "sparseCheckout": [],
             "type": "git",
             "url": "https://github.com/datadog-labs/pup"
         },
-        "version": "5c47c9c49a72417984a9db2540d2dbc5a0150b69"
+        "version": "28dd51b42f1cfb8b94f3e7f1661e77c67e9d5907"
     },
     "vercel-skills-cli": {
         "cargoLock": null,
-        "date": "2026-08-07",
+        "date": "2026-08-10",
         "extract": null,
         "name": "vercel-skills-cli",
         "passthru": null,
@@ -376,13 +376,13 @@
             "fetchSubmodules": false,
             "leaveDotGit": false,
             "name": null,
-            "rev": "941a7bcfeca4bf07913b9fb6f8ed81f20ff5297c",
-            "sha256": "sha256-PLt/ECv/rg9viV6JzfEoBfBo+ELsMpcXfS6OZ4saDhk=",
+            "rev": "c6f69c631292444cc541ac6d91e2226b0ff247da",
+            "sha256": "sha256-ysEI0AfD360OBRSKX+5HX60DCo0gM0eiuUkpfMIqZOg=",
             "sparseCheckout": [],
             "type": "git",
             "url": "https://github.com/vercel-labs/skills"
         },
-        "version": "941a7bcfeca4bf07913b9fb6f8ed81f20ff5297c"
+        "version": "c6f69c631292444cc541ac6d91e2226b0ff247da"
     },
     "wacli": {
         "cargoLock": null,
@@ -401,7 +401,7 @@
     },
     "worktrunk-skills": {
         "cargoLock": null,
-        "date": "2026-08-09",
+        "date": "2026-08-10",
         "extract": null,
         "name": "worktrunk-skills",
         "passthru": null,
@@ -411,13 +411,13 @@
             "fetchSubmodules": false,
             "leaveDotGit": false,
             "name": null,
-            "rev": "897f7d71938e15a4b446281c61f1fbb2c5767d18",
-            "sha256": "sha256-91e7nnfxmQQFG6df0az9995QSUzWOTj5EdTE7XaihGg=",
+            "rev": "8bf8ae44a50f58aeba886474f81faf94bb114cf1",
+            "sha256": "sha256-bdTHvOvU0kQVxS081ZU8i+jHszbuzijpYLnMpHB8vHo=",
             "sparseCheckout": [],
             "type": "git",
             "url": "https://github.com/max-sixty/worktrunk"
         },
-        "version": "897f7d71938e15a4b446281c61f1fbb2c5767d18"
+        "version": "8bf8ae44a50f58aeba886474f81faf94bb114cf1"
     },
     "wshobson-agents": {
         "cargoLock": null,

--- a/_sources/generated.json
+++ b/_sources/generated.json
@@ -76,7 +76,7 @@
     },
     "chrome-devtools-mcp-skills": {
         "cargoLock": null,
-        "date": "2026-08-07",
+        "date": "2026-08-10",
         "extract": null,
         "name": "chrome-devtools-mcp-skills",
         "passthru": null,
@@ -86,13 +86,13 @@
             "fetchSubmodules": false,
             "leaveDotGit": false,
             "name": null,
-            "rev": "8028bfe3abaecb67422530d05327c5ec72c53753",
-            "sha256": "sha256-h3sfnIoxPK6ckmccE2/g6Za+A6anjFv282nWAqlPlUM=",
+            "rev": "073d4a39e9c96b17936d3cdc4bdea69977f0cca6",
+            "sha256": "sha256-YtKbV3d+xNLWR1cdlDW7HwOW8EV3sambcUDDUzfkh2k=",
             "sparseCheckout": [],
             "type": "git",
             "url": "https://github.com/ChromeDevTools/chrome-devtools-mcp"
         },
-        "version": "8028bfe3abaecb67422530d05327c5ec72c53753"
+        "version": "073d4a39e9c96b17936d3cdc4bdea69977f0cca6"
     },
     "claude-mem": {
         "cargoLock": null,
@@ -111,7 +111,7 @@
     },
     "context7-skills": {
         "cargoLock": null,
-        "date": "2026-08-09",
+        "date": "2026-08-10",
         "extract": null,
         "name": "context7-skills",
         "passthru": null,
@@ -121,13 +121,13 @@
             "fetchSubmodules": false,
             "leaveDotGit": false,
             "name": null,
-            "rev": "6a799754d01aa27f1eee40d712651ebc31ffedce",
-            "sha256": "sha256-QTkRTESdC3EeXG+iDRHjjUuhniqIKhPZY4CU+UzcM1g=",
+            "rev": "895c5c399752109be3bd78fa5f0c2e1f5b5a1420",
+            "sha256": "sha256-kBESFdZn+zVDnWvAhGgjhRw3mDRyO9jfjl6pZDkT4N0=",
             "sparseCheckout": [],
             "type": "git",
             "url": "https://github.com/upstash/context7"
         },
-        "version": "6a799754d01aa27f1eee40d712651ebc31ffedce"
+        "version": "895c5c399752109be3bd78fa5f0c2e1f5b5a1420"
     },
     "dot-skills": {
         "cargoLock": null,
@@ -268,11 +268,11 @@
         "pinned": false,
         "src": {
             "name": null,
-            "sha256": "sha256-OOP6/4ciaLFn6NbjHUR9rFiE+7GxvvJMXm7kxfFXoz4=",
+            "sha256": "sha256-ErfX1tMJo3A5DMBXg2mpYoS/E2MAvMJE8xNZ6LIgaZo=",
             "type": "url",
-            "url": "https://github.com/code-yeongyu/oh-my-openagent/archive/refs/tags/v5.0.0-beta.3.tar.gz"
+            "url": "https://github.com/code-yeongyu/oh-my-openagent/archive/refs/tags/v5.0.0-beta.5.tar.gz"
         },
-        "version": "5.0.0-beta.3"
+        "version": "5.0.0-beta.5"
     },
     "omp": {
         "cargoLock": null,
@@ -291,7 +291,7 @@
     },
     "orca-skills": {
         "cargoLock": null,
-        "date": "2026-08-09",
+        "date": "2026-08-10",
         "extract": null,
         "name": "orca-skills",
         "passthru": null,
@@ -301,13 +301,13 @@
             "fetchSubmodules": false,
             "leaveDotGit": false,
             "name": null,
-            "rev": "a3ca887a3c08439a89c9ce7db95f480ef29c5384",
-            "sha256": "sha256-OTgfDmXLRL5KT52+JWbMQrcIVrcy5qVM0cElXENFSuI=",
+            "rev": "56b6d845e013f7e94d3a031ad7e22b9de0821056",
+            "sha256": "sha256-emEEskprW0IWM8Lj445q5vSbA1HaNVekq+sJXErQEZQ=",
             "sparseCheckout": [],
             "type": "git",
             "url": "https://github.com/stablyai/orca"
         },
-        "version": "a3ca887a3c08439a89c9ce7db95f480ef29c5384"
+        "version": "56b6d845e013f7e94d3a031ad7e22b9de0821056"
     },
     "playwriter-skills": {
         "cargoLock": null,

--- a/_sources/generated.nix
+++ b/_sources/generated.nix
@@ -8,17 +8,17 @@
 {
   agent-browser-skills = {
     pname = "agent-browser-skills";
-    version = "acbc22bdc5d4f6c5a88d97d4a4745d3c5eb0591f";
+    version = "861e76ddf48ea48f4ce5fe0e79dc725b084d0e8b";
     src = fetchgit {
       url = "https://github.com/vercel-labs/agent-browser";
-      rev = "acbc22bdc5d4f6c5a88d97d4a4745d3c5eb0591f";
+      rev = "861e76ddf48ea48f4ce5fe0e79dc725b084d0e8b";
       fetchSubmodules = false;
       deepClone = false;
       leaveDotGit = false;
       sparseCheckout = [ ];
-      sha256 = "sha256-GtN5IvyBSvOJ76lB5LSYNGr1m9MhpBDNASG/8iH3tVM=";
+      sha256 = "sha256-zsXcEBAdEMdtFX63idphwYerpdgYBMskJ7utuKiHqTI=";
     };
-    date = "2026-08-05";
+    date = "2026-08-10";
   };
   agent-slack = {
     pname = "agent-slack";
@@ -72,10 +72,10 @@
   };
   claude-mem = {
     pname = "claude-mem";
-    version = "13.14.0";
+    version = "13.15.0";
     src = fetchurl {
-      url = "https://registry.npmjs.org/claude-mem/-/claude-mem-13.14.0.tgz";
-      sha256 = "sha256-37uDw1ySeT/zArYzAIEhu5fihv+ZJvq2hjFl2J+SFR0=";
+      url = "https://registry.npmjs.org/claude-mem/-/claude-mem-13.15.0.tgz";
+      sha256 = "sha256-bYkIvYqFmsZg7Nf2kiChX+4Y+xDVHwJr+FzLk58Z0E0=";
     };
   };
   context7-skills = {
@@ -196,15 +196,15 @@
   };
   orca-skills = {
     pname = "orca-skills";
-    version = "56b6d845e013f7e94d3a031ad7e22b9de0821056";
+    version = "8da362919e4a79122b6655c778d8808c690ec47e";
     src = fetchgit {
       url = "https://github.com/stablyai/orca";
-      rev = "56b6d845e013f7e94d3a031ad7e22b9de0821056";
+      rev = "8da362919e4a79122b6655c778d8808c690ec47e";
       fetchSubmodules = false;
       deepClone = false;
       leaveDotGit = false;
       sparseCheckout = [ ];
-      sha256 = "sha256-emEEskprW0IWM8Lj445q5vSbA1HaNVekq+sJXErQEZQ=";
+      sha256 = "sha256-uuaMHpDtIRsW+xx1NAQ7ypoBxwSlSw4xRP8Ig8eMFJc=";
     };
     date = "2026-08-10";
   };
@@ -232,31 +232,31 @@
   };
   pup-skills = {
     pname = "pup-skills";
-    version = "5c47c9c49a72417984a9db2540d2dbc5a0150b69";
+    version = "28dd51b42f1cfb8b94f3e7f1661e77c67e9d5907";
     src = fetchgit {
       url = "https://github.com/datadog-labs/pup";
-      rev = "5c47c9c49a72417984a9db2540d2dbc5a0150b69";
+      rev = "28dd51b42f1cfb8b94f3e7f1661e77c67e9d5907";
       fetchSubmodules = false;
       deepClone = false;
       leaveDotGit = false;
       sparseCheckout = [ ];
-      sha256 = "sha256-PSfWundBHpT0fgkeSB0bB2QANSvtWQy+HbcSfFirBpc=";
+      sha256 = "sha256-rl51fqtaXDoa9l91WsvTbVWBOz/YtCopvcHSUaEtzb4=";
     };
-    date = "2026-08-07";
+    date = "2026-08-10";
   };
   vercel-skills-cli = {
     pname = "vercel-skills-cli";
-    version = "941a7bcfeca4bf07913b9fb6f8ed81f20ff5297c";
+    version = "c6f69c631292444cc541ac6d91e2226b0ff247da";
     src = fetchgit {
       url = "https://github.com/vercel-labs/skills";
-      rev = "941a7bcfeca4bf07913b9fb6f8ed81f20ff5297c";
+      rev = "c6f69c631292444cc541ac6d91e2226b0ff247da";
       fetchSubmodules = false;
       deepClone = false;
       leaveDotGit = false;
       sparseCheckout = [ ];
-      sha256 = "sha256-PLt/ECv/rg9viV6JzfEoBfBo+ELsMpcXfS6OZ4saDhk=";
+      sha256 = "sha256-ysEI0AfD360OBRSKX+5HX60DCo0gM0eiuUkpfMIqZOg=";
     };
-    date = "2026-08-07";
+    date = "2026-08-10";
   };
   wacli = {
     pname = "wacli";
@@ -268,17 +268,17 @@
   };
   worktrunk-skills = {
     pname = "worktrunk-skills";
-    version = "897f7d71938e15a4b446281c61f1fbb2c5767d18";
+    version = "8bf8ae44a50f58aeba886474f81faf94bb114cf1";
     src = fetchgit {
       url = "https://github.com/max-sixty/worktrunk";
-      rev = "897f7d71938e15a4b446281c61f1fbb2c5767d18";
+      rev = "8bf8ae44a50f58aeba886474f81faf94bb114cf1";
       fetchSubmodules = false;
       deepClone = false;
       leaveDotGit = false;
       sparseCheckout = [ ];
-      sha256 = "sha256-91e7nnfxmQQFG6df0az9995QSUzWOTj5EdTE7XaihGg=";
+      sha256 = "sha256-bdTHvOvU0kQVxS081ZU8i+jHszbuzijpYLnMpHB8vHo=";
     };
-    date = "2026-08-09";
+    date = "2026-08-10";
   };
   wshobson-agents = {
     pname = "wshobson-agents";

--- a/_sources/generated.nix
+++ b/_sources/generated.nix
@@ -58,17 +58,17 @@
   };
   chrome-devtools-mcp-skills = {
     pname = "chrome-devtools-mcp-skills";
-    version = "8028bfe3abaecb67422530d05327c5ec72c53753";
+    version = "073d4a39e9c96b17936d3cdc4bdea69977f0cca6";
     src = fetchgit {
       url = "https://github.com/ChromeDevTools/chrome-devtools-mcp";
-      rev = "8028bfe3abaecb67422530d05327c5ec72c53753";
+      rev = "073d4a39e9c96b17936d3cdc4bdea69977f0cca6";
       fetchSubmodules = false;
       deepClone = false;
       leaveDotGit = false;
       sparseCheckout = [ ];
-      sha256 = "sha256-h3sfnIoxPK6ckmccE2/g6Za+A6anjFv282nWAqlPlUM=";
+      sha256 = "sha256-YtKbV3d+xNLWR1cdlDW7HwOW8EV3sambcUDDUzfkh2k=";
     };
-    date = "2026-08-07";
+    date = "2026-08-10";
   };
   claude-mem = {
     pname = "claude-mem";
@@ -80,17 +80,17 @@
   };
   context7-skills = {
     pname = "context7-skills";
-    version = "6a799754d01aa27f1eee40d712651ebc31ffedce";
+    version = "895c5c399752109be3bd78fa5f0c2e1f5b5a1420";
     src = fetchgit {
       url = "https://github.com/upstash/context7";
-      rev = "6a799754d01aa27f1eee40d712651ebc31ffedce";
+      rev = "895c5c399752109be3bd78fa5f0c2e1f5b5a1420";
       fetchSubmodules = false;
       deepClone = false;
       leaveDotGit = false;
       sparseCheckout = [ ];
-      sha256 = "sha256-QTkRTESdC3EeXG+iDRHjjUuhniqIKhPZY4CU+UzcM1g=";
+      sha256 = "sha256-kBESFdZn+zVDnWvAhGgjhRw3mDRyO9jfjl6pZDkT4N0=";
     };
-    date = "2026-08-09";
+    date = "2026-08-10";
   };
   dot-skills = {
     pname = "dot-skills";
@@ -180,10 +180,10 @@
   };
   oh-my-openagent = {
     pname = "oh-my-openagent";
-    version = "5.0.0-beta.3";
+    version = "5.0.0-beta.5";
     src = fetchurl {
-      url = "https://github.com/code-yeongyu/oh-my-openagent/archive/refs/tags/v5.0.0-beta.3.tar.gz";
-      sha256 = "sha256-OOP6/4ciaLFn6NbjHUR9rFiE+7GxvvJMXm7kxfFXoz4=";
+      url = "https://github.com/code-yeongyu/oh-my-openagent/archive/refs/tags/v5.0.0-beta.5.tar.gz";
+      sha256 = "sha256-ErfX1tMJo3A5DMBXg2mpYoS/E2MAvMJE8xNZ6LIgaZo=";
     };
   };
   omp = {
@@ -196,17 +196,17 @@
   };
   orca-skills = {
     pname = "orca-skills";
-    version = "a3ca887a3c08439a89c9ce7db95f480ef29c5384";
+    version = "56b6d845e013f7e94d3a031ad7e22b9de0821056";
     src = fetchgit {
       url = "https://github.com/stablyai/orca";
-      rev = "a3ca887a3c08439a89c9ce7db95f480ef29c5384";
+      rev = "56b6d845e013f7e94d3a031ad7e22b9de0821056";
       fetchSubmodules = false;
       deepClone = false;
       leaveDotGit = false;
       sparseCheckout = [ ];
-      sha256 = "sha256-OTgfDmXLRL5KT52+JWbMQrcIVrcy5qVM0cElXENFSuI=";
+      sha256 = "sha256-emEEskprW0IWM8Lj445q5vSbA1HaNVekq+sJXErQEZQ=";
     };
-    date = "2026-08-09";
+    date = "2026-08-10";
   };
   playwriter-skills = {
     pname = "playwriter-skills";

--- a/devenv.lock
+++ b/devenv.lock
@@ -3,11 +3,11 @@
     "devenv": {
       "locked": {
         "dir": "src/modules",
-        "lastModified": 1786318641,
-        "narHash": "sha256-XtGARxGaiWgeWDvg3D3gVmynCtVnoBsEh/hQm8oVLe0=",
+        "lastModified": 1786358125,
+        "narHash": "sha256-rbuRaHNIvv4J59JEualb8xrqFhPBze3QflesC96kY9k=",
         "owner": "cachix",
         "repo": "devenv",
-        "rev": "4158f6bffa1ac70104e390f8b5b5f59b3a23cbb0",
+        "rev": "49386681992dd2d8cf41a226b5bd0c558984f7a1",
         "type": "github"
       },
       "original": {
@@ -56,11 +56,11 @@
     },
     "nixpkgs": {
       "locked": {
-        "lastModified": 1785975029,
-        "narHash": "sha256-X44cn5rzytELc3NNoQsh0aLkjWA/QzPfc6HPQmsG3sU=",
+        "lastModified": 1786098110,
+        "narHash": "sha256-shi1tjDhCGGd0kIgVPNY03V8NBWSTzhMSFDb7IqSoec=",
         "owner": "NixOS",
         "repo": "nixpkgs",
-        "rev": "70ce234312134a463ba7728e94da2486a1d237ac",
+        "rev": "afb4584a80bbf779ce0f691509ff902d188c2b3d",
         "type": "github"
       },
       "original": {

--- a/devenv.lock
+++ b/devenv.lock
@@ -3,11 +3,11 @@
     "devenv": {
       "locked": {
         "dir": "src/modules",
-        "lastModified": 1786358125,
-        "narHash": "sha256-rbuRaHNIvv4J59JEualb8xrqFhPBze3QflesC96kY9k=",
+        "lastModified": 1786393935,
+        "narHash": "sha256-2BkSKTW/8N+G/9ZIEsWGWkqqm2PjqfMjgwo+IhiElIw=",
         "owner": "cachix",
         "repo": "devenv",
-        "rev": "49386681992dd2d8cf41a226b5bd0c558984f7a1",
+        "rev": "ddacdc79d07d28fb857d024299fb86f1e38eeb17",
         "type": "github"
       },
       "original": {

--- a/flake.lock
+++ b/flake.lock
@@ -293,11 +293,11 @@
         "treefmt-nix": "treefmt-nix"
       },
       "locked": {
-        "lastModified": 1786323141,
-        "narHash": "sha256-IiNvo9rlL9ncnLOp70Mo1toobC2t9xHzsZIZayEv7dg=",
+        "lastModified": 1786337855,
+        "narHash": "sha256-UG8v0D6MCJs7TCpdpAOLKus+IHktnt4MlV19kFLZQ2w=",
         "owner": "numtide",
         "repo": "llm-agents.nix",
-        "rev": "76f2e1f07e0435873d08e7f8a07dbe18f237ec5c",
+        "rev": "33656317a15ef8171dc2efbbdefd5f7b092b57b9",
         "type": "github"
       },
       "original": {

--- a/flake.lock
+++ b/flake.lock
@@ -32,11 +32,11 @@
         ]
       },
       "locked": {
-        "lastModified": 1785909051,
-        "narHash": "sha256-wR7wgld8IVJ2C2CWJtgd56ZFyUK8SEWN/NyCRygwDAg=",
+        "lastModified": 1786379373,
+        "narHash": "sha256-zrvcpGFA8zG6yRLBqQH9bNkJap8xMvLNvkuT4+7w6X8=",
         "owner": "Kyure-A",
         "repo": "agent-skills-nix",
-        "rev": "d86bab6d839202d838ed1451a64a94d3f0718f5b",
+        "rev": "1594ba479be81a7cb6dd19faabefcb1ed5b3f964",
         "type": "github"
       },
       "original": {
@@ -102,15 +102,15 @@
     },
     "claude-code-nix": {
       "inputs": {
-        "flake-utils": "flake-utils",
-        "nixpkgs": "nixpkgs"
+        "nixpkgs": "nixpkgs",
+        "systems": "systems_3"
       },
       "locked": {
-        "lastModified": 1786159714,
-        "narHash": "sha256-Rm3yXcjHmoebdRA35SVy/AM9PsckDPPJkY+xGodiIHQ=",
+        "lastModified": 1786384113,
+        "narHash": "sha256-Spc+2E3qAl6x16nW6dnrsu5Fx+YBitEi3Caxpea5wqQ=",
         "owner": "sadjow",
         "repo": "claude-code-nix",
-        "rev": "9bf9ac959eaee3b06d6ef13f18a711ae64a581b4",
+        "rev": "e54a54c423925d7b309231f7c58867ccb81e96f3",
         "type": "github"
       },
       "original": {
@@ -203,24 +203,6 @@
         "type": "github"
       }
     },
-    "flake-utils": {
-      "inputs": {
-        "systems": "systems_3"
-      },
-      "locked": {
-        "lastModified": 1731533236,
-        "narHash": "sha256-l0KFg5HjrsfsO/JpG+r7fRrqm12kzFHyUHqHCVpMMbI=",
-        "owner": "numtide",
-        "repo": "flake-utils",
-        "rev": "11707dc2f618dd54ca8739b309ec4fc024de578b",
-        "type": "github"
-      },
-      "original": {
-        "owner": "numtide",
-        "repo": "flake-utils",
-        "type": "github"
-      }
-    },
     "home-manager": {
       "inputs": {
         "nixpkgs": [
@@ -293,11 +275,11 @@
         "treefmt-nix": "treefmt-nix"
       },
       "locked": {
-        "lastModified": 1786337855,
-        "narHash": "sha256-UG8v0D6MCJs7TCpdpAOLKus+IHktnt4MlV19kFLZQ2w=",
+        "lastModified": 1786398103,
+        "narHash": "sha256-1YE1xiDTvSuYAmuZdGXyMGYuqg7v7PEI1OxIohc4u8E=",
         "owner": "numtide",
         "repo": "llm-agents.nix",
-        "rev": "33656317a15ef8171dc2efbbdefd5f7b092b57b9",
+        "rev": "387989ee56d550d86d46d9458ad68a55b9e0ca3b",
         "type": "github"
       },
       "original": {
@@ -324,11 +306,11 @@
     },
     "nixpkgs_2": {
       "locked": {
-        "lastModified": 1785975029,
-        "narHash": "sha256-X44cn5rzytELc3NNoQsh0aLkjWA/QzPfc6HPQmsG3sU=",
+        "lastModified": 1786098110,
+        "narHash": "sha256-shi1tjDhCGGd0kIgVPNY03V8NBWSTzhMSFDb7IqSoec=",
         "owner": "NixOS",
         "repo": "nixpkgs",
-        "rev": "70ce234312134a463ba7728e94da2486a1d237ac",
+        "rev": "afb4584a80bbf779ce0f691509ff902d188c2b3d",
         "type": "github"
       },
       "original": {

--- a/modules/home-manager/packages/mole/package.nix
+++ b/modules/home-manager/packages/mole/package.nix
@@ -16,7 +16,7 @@ buildGoModule {
     "cmd/status"
   ];
 
-  vendorHash = "sha256-fWmki7xFZzNU3+A3Ge60YnKkqXa7nf0sDmOIjGyf+RE=";
+  vendorHash = "sha256-Q7VzGJ1bGAyMi2Ih3LvI92lCVqxKIyr7H89LAFczNbo=";
 
   # Release builds are pure-Go (Makefile sets CGO_ENABLED=0); match that so the
   # gopsutil dependency uses its cgo-free path.


### PR DESCRIPTION
- Refresh flake, devenv, and nvfetcher pins.
- Update Mole’s Go dependency hash for version 1.50.0.