### PR TITLE
Move Nix stack to unstable

### DIFF
--- a/flake.lock
+++ b/flake.lock
@@ -148,16 +148,16 @@
         ]
       },
       "locked": {
-        "lastModified": 1783744694,
-        "narHash": "sha256-2cp6N3rrwnGYLTx9l6N+NI+kwrCWxvJUbj5WJhvB29A=",
+        "lastModified": 1785389976,
+        "narHash": "sha256-0tLW8Ff5yt8AH97jw4ZpFJ0OCJ122zIlgWGDmOfU/VU=",
         "owner": "nix-darwin",
         "repo": "nix-darwin",
-        "rev": "c3e90c89649b07d1a96e4b9dd6cd0d6e44b91a74",
+        "rev": "15abb8c98f336cd8bd840d71059adebabe60bf04",
         "type": "github"
       },
       "original": {
         "owner": "nix-darwin",
-        "ref": "nix-darwin-26.05",
+        "ref": "master",
         "repo": "nix-darwin",
         "type": "github"
       }
@@ -252,16 +252,16 @@
         ]
       },
       "locked": {
-        "lastModified": 1785119570,
-        "narHash": "sha256-Rgs2xKnGLFWQscxUaXX07oyZeuMDOHEbqDOsgliLFGM=",
+        "lastModified": 1786356609,
+        "narHash": "sha256-ou8fYz5w9yhXC8YbvvExybFIa19MyW5G/8dEPqa90hM=",
         "owner": "nix-community",
         "repo": "home-manager",
-        "rev": "d4fd24667c8cbef124bb70a20380cab75ec8474d",
+        "rev": "c30c7955cec30d664a9baced6bc0112e263d4647",
         "type": "github"
       },
       "original": {
         "owner": "nix-community",
-        "ref": "release-26.05",
+        "ref": "master",
         "repo": "home-manager",
         "type": "github"
       }
@@ -322,16 +322,16 @@
     },
     "nixpkgs_3": {
       "locked": {
-        "lastModified": 1786152057,
-        "narHash": "sha256-bzEqlLh3EpIhdSDEb4zWy6w39QbZz/OHR8xEBeY6ZwA=",
+        "lastModified": 1786098110,
+        "narHash": "sha256-shi1tjDhCGGd0kIgVPNY03V8NBWSTzhMSFDb7IqSoec=",
         "owner": "NixOS",
         "repo": "nixpkgs",
-        "rev": "6241c49fffa016352c8e757decbdb20541aa9cb2",
+        "rev": "afb4584a80bbf779ce0f691509ff902d188c2b3d",
         "type": "github"
       },
       "original": {
         "owner": "NixOS",
-        "ref": "nixpkgs-26.05-darwin",
+        "ref": "nixpkgs-unstable",
         "repo": "nixpkgs",
         "type": "github"
       }

--- a/flake.nix
+++ b/flake.nix
@@ -2,15 +2,15 @@
   description = "mattietea's system configuration";
 
   inputs = {
-    nixpkgs.url = "github:NixOS/nixpkgs/nixpkgs-26.05-darwin";
+    nixpkgs.url = "github:NixOS/nixpkgs/nixpkgs-unstable";
 
     flake-parts.url = "github:hercules-ci/flake-parts";
     flake-parts.inputs.nixpkgs-lib.follows = "nixpkgs";
 
-    darwin.url = "github:nix-darwin/nix-darwin/nix-darwin-26.05";
+    darwin.url = "github:nix-darwin/nix-darwin/master";
     darwin.inputs.nixpkgs.follows = "nixpkgs";
 
-    home-manager.url = "github:nix-community/home-manager/release-26.05";
+    home-manager.url = "github:nix-community/home-manager/master";
     home-manager.inputs.nixpkgs.follows = "nixpkgs";
 
     # NOTE: no nixpkgs follows — llm-agents ships pre-built binaries via cache.numtide.com;

--- a/modules/home-manager/packages/fzf/default.nix
+++ b/modules/home-manager/packages/fzf/default.nix
@@ -16,23 +16,27 @@
         "--layout=reverse"
         "--info=inline"
       ];
-      fileWidgetCommand = "${pkgs.fd}/bin/fd --type f --hidden --follow --exclude .git";
-      fileWidgetOptions = [
-        "--height 100%"
-        "--layout=reverse"
-        "--info=inline"
-        "--preview '${pkgs.bat}/bin/bat --color=always --style=numbers --line-range=:500 --wrap=auto {}'"
-        "--border=none"
-        "--preview-window=noborder"
-      ];
-      changeDirWidgetCommand = "${pkgs.fd}/bin/fd --type d --hidden --follow --exclude .git";
-      changeDirWidgetOptions = [
-        "--height 100%"
-        "--info=inline"
-        "--preview '${pkgs.eza}/bin/eza --tree --color=always --icons {}'"
-        "--border=none"
-        "--preview-window=noborder"
-      ];
+      fileWidget = {
+        command = "${pkgs.fd}/bin/fd --type f --hidden --follow --exclude .git";
+        options = [
+          "--height 100%"
+          "--layout=reverse"
+          "--info=inline"
+          "--preview '${pkgs.bat}/bin/bat --color=always --style=numbers --line-range=:500 --wrap=auto {}'"
+          "--border=none"
+          "--preview-window=noborder"
+        ];
+      };
+      changeDirWidget = {
+        command = "${pkgs.fd}/bin/fd --type d --hidden --follow --exclude .git";
+        options = [
+          "--height 100%"
+          "--info=inline"
+          "--preview '${pkgs.eza}/bin/eza --tree --color=always --icons {}'"
+          "--border=none"
+          "--preview-window=noborder"
+        ];
+      };
     };
   };
 }


### PR DESCRIPTION
- Track nixpkgs unstable with nix-darwin and Home Manager master.
- Upgrade the packaged devenv CLI to 2.2.1.
- Migrate fzf widget settings to the current Home Manager options.