### PR TITLE
Restrict omp skills to the nix-managed user set

### DIFF
--- a/modules/ai/harnesses/omp/default.nix
+++ b/modules/ai/harnesses/omp/default.nix
@@ -1,4 +1,5 @@
 {
+  config,
   pkgs,
   lib,
   inputs,
@@ -14,7 +15,10 @@ in
     packages = [ inputs.llm-agents.packages.${pkgs.stdenv.hostPlatform.system}.omp ];
 
     file.".omp/agent/config.yml".source = yamlFormat.generate "omp-config.yml" (
-      import ./settings.nix // { modelRoles = import ./roles.nix; }
+      import ./settings.nix { inherit (config.home) homeDirectory; }
+      // {
+        modelRoles = import ./roles.nix;
+      }
     );
 
     # Orca launches omp with PI_CODING_AGENT_DIR pointed at a per-workspace

--- a/modules/ai/harnesses/omp/settings.nix
+++ b/modules/ai/harnesses/omp/settings.nix
@@ -1,5 +1,6 @@
 # Shared config.yml payload for omp. Each host variant merges its own
 # modelRoles on top (base roles in ./default.nix, work roles in ./work.nix).
+{ homeDirectory }:
 {
   # omp persists setup-wizard completion into config.yml, which is a
   # read-only nix symlink here — so pin the wizard state declaratively.
@@ -22,13 +23,20 @@
     # Auto-run one capture turn at stop instead of a passive reminder.
     autoContinue = true;
   };
-  # User-level skills only; don't pick up skills shipped inside repos
-  # (.claude/skills, .omp/skills, .agents/skills). Note .github/skills has
-  # no dedicated toggle and stays active while any user source is enabled.
+  # Only nix-managed skills. Disabling every named source toggle also turns
+  # off the toggle-less providers (github .github/skills, opencode,
+  # claude-plugins), which stay active while ANY named source is enabled —
+  # so project repos can't inject skills from any layout. The user skill set
+  # is served back through customDirectories instead.
   skills = {
+    enableCodexUser = false;
+    enableClaudeUser = false;
     enableClaudeProject = false;
+    enablePiUser = false;
     enablePiProject = false;
+    enableAgentsUser = false;
     enableAgentsProject = false;
+    customDirectories = [ "${homeDirectory}/.agents/skills" ];
   };
   advisor.enabled = true;
 }

--- a/modules/ai/harnesses/omp/work.nix
+++ b/modules/ai/harnesses/omp/work.nix
@@ -1,4 +1,5 @@
 {
+  config,
   pkgs,
   lib,
   ...
@@ -19,6 +20,8 @@ let
 in
 {
   home.file.".omp/agent/config.yml".source = lib.mkForce (
-    yamlFormat.generate "omp-config.yml" (import ./settings.nix // { modelRoles = roles; })
+    yamlFormat.generate "omp-config.yml" (
+      import ./settings.nix { inherit (config.home) homeDirectory; } // { modelRoles = roles; }
+    )
   );
 }


### PR DESCRIPTION
- Disable every omp skill source toggle so repos can't inject skills from any layout (.claude, .agents, .omp, .github, opencode)
- Serve the nix-managed skill set back via skills.customDirectories (~/.agents/skills)
- Verified in a repo shipping 15 project skills: none load, user skills remain