### PR TITLE
Remove chrome-devtools MCP server and skills

### DIFF
--- a/_sources/generated.json
+++ b/_sources/generated.json
@@ -74,26 +74,6 @@
         },
         "version": "f17010c9bb483898c1d9c9f42dde2b3a98889434"
     },
-    "chrome-devtools-mcp-skills": {
-        "cargoLock": null,
-        "date": "2026-08-10",
-        "extract": null,
-        "name": "chrome-devtools-mcp-skills",
-        "passthru": null,
-        "pinned": false,
-        "src": {
-            "deepClone": false,
-            "fetchSubmodules": false,
-            "leaveDotGit": false,
-            "name": null,
-            "rev": "073d4a39e9c96b17936d3cdc4bdea69977f0cca6",
-            "sha256": "sha256-YtKbV3d+xNLWR1cdlDW7HwOW8EV3sambcUDDUzfkh2k=",
-            "sparseCheckout": [],
-            "type": "git",
-            "url": "https://github.com/ChromeDevTools/chrome-devtools-mcp"
-        },
-        "version": "073d4a39e9c96b17936d3cdc4bdea69977f0cca6"
-    },
     "claude-mem": {
         "cargoLock": null,
         "date": null,
@@ -273,21 +253,6 @@
             "url": "https://github.com/code-yeongyu/oh-my-openagent/archive/refs/tags/v5.0.0-beta.5.tar.gz"
         },
         "version": "5.0.0-beta.5"
-    },
-    "omp": {
-        "cargoLock": null,
-        "date": null,
-        "extract": null,
-        "name": "omp",
-        "passthru": null,
-        "pinned": false,
-        "src": {
-            "name": null,
-            "sha256": "sha256-q0/yTIujrm/Z1LVJaclPRAjMMWZ19VNHKa5QLYyX33Q=",
-            "type": "url",
-            "url": "https://github.com/can1357/oh-my-pi/releases/download/v17.2.12/omp-darwin-arm64"
-        },
-        "version": "17.2.12"
     },
     "orca-arm64": {
         "cargoLock": null,

--- a/_sources/generated.nix
+++ b/_sources/generated.nix
@@ -56,20 +56,6 @@
     };
     date = "2026-08-07";
   };
-  chrome-devtools-mcp-skills = {
-    pname = "chrome-devtools-mcp-skills";
-    version = "073d4a39e9c96b17936d3cdc4bdea69977f0cca6";
-    src = fetchgit {
-      url = "https://github.com/ChromeDevTools/chrome-devtools-mcp";
-      rev = "073d4a39e9c96b17936d3cdc4bdea69977f0cca6";
-      fetchSubmodules = false;
-      deepClone = false;
-      leaveDotGit = false;
-      sparseCheckout = [ ];
-      sha256 = "sha256-YtKbV3d+xNLWR1cdlDW7HwOW8EV3sambcUDDUzfkh2k=";
-    };
-    date = "2026-08-10";
-  };
   claude-mem = {
     pname = "claude-mem";
     version = "13.15.0";
@@ -184,14 +170,6 @@
     src = fetchurl {
       url = "https://github.com/code-yeongyu/oh-my-openagent/archive/refs/tags/v5.0.0-beta.5.tar.gz";
       sha256 = "sha256-ErfX1tMJo3A5DMBXg2mpYoS/E2MAvMJE8xNZ6LIgaZo=";
-    };
-  };
-  omp = {
-    pname = "omp";
-    version = "17.2.12";
-    src = fetchurl {
-      url = "https://github.com/can1357/oh-my-pi/releases/download/v17.2.12/omp-darwin-arm64";
-      sha256 = "sha256-q0/yTIujrm/Z1LVJaclPRAjMMWZ19VNHKa5QLYyX33Q=";
     };
   };
   orca-arm64 = {

--- a/lib/mkHost.nix
+++ b/lib/mkHost.nix
@@ -38,15 +38,9 @@ inputs.darwin.lib.darwinSystem {
     {
       age = {
         identityPaths = [ "/Users/${settings.username}/.ssh/id_ed25519" ];
-        secrets = {
-          context7-api-key = {
-            file = ../secrets/context7-api-key.age;
-            owner = settings.username;
-          };
-          exa-api-key = {
-            file = ../secrets/exa-api-key.age;
-            owner = settings.username;
-          };
+        secrets.context7-api-key = {
+          file = ../secrets/context7-api-key.age;
+          owner = settings.username;
         };
       };
     }

--- a/modules/ai/instructions/INSTRUCTIONS.md
+++ b/modules/ai/instructions/INSTRUCTIONS.md
@@ -106,12 +106,6 @@ Make surgical changes — every changed line should trace directly to the reques
 
 </important>
 
-<important if="you need to search the web for information">
-
-Use **Exa** (MCP server) first — higher quality, focused results. Fall back to generic web search only when Exa doesn't cover the topic.
-
-</important>
-
 <important if="I ask you to look at a tab, browser tab, or any of my open tabs">
 
 Use the **playwriter** skill. Playwriter connects to my running Chrome via a browser extension, so my logins, cookies, and extensions are already there — unlike agent-browser which spawns a fresh browser.

--- a/modules/ai/instructions/INSTRUCTIONS.md
+++ b/modules/ai/instructions/INSTRUCTIONS.md
@@ -120,7 +120,7 @@ Use the **playwriter** skill. Playwriter connects to my running Chrome via a bro
 
 <important if="you are asked to load a website, visit a URL, fill a form, or interact with a web page (and it is NOT one of my already-open browser tabs)">
 
-Use the **agent-browser** skill. Only use Chrome DevTools MCP when I explicitly ask for DevTools, debugging, performance analysis, or network inspection. If I am referring to a tab in my running Chrome, use the **playwriter** skill instead.
+Use the **agent-browser** skill. If I am referring to a tab in my running Chrome, use the **playwriter** skill instead.
 
 </important>
 

--- a/modules/ai/mcp/default.nix
+++ b/modules/ai/mcp/default.nix
@@ -1,19 +1,5 @@
-{
-  pkgs,
-  ...
-}:
-{
-  programs.mcp = {
-    enable = true;
-    servers = {
-      exa = {
-        type = "stdio";
-        command = "${pkgs.writeShellScript "exa-mcp" ''
-          export EXA_API_KEY="$(cat /run/agenix/exa-api-key)"
-          exec npx -y exa-mcp-server
-        ''}";
-        args = [ ];
-      };
-    };
-  };
+# Base MCP config is just the enable switch; servers are host-specific
+# (work adds its set in ./work.nix).
+_: {
+  programs.mcp.enable = true;
 }

--- a/modules/ai/mcp/work.nix
+++ b/modules/ai/mcp/work.nix
@@ -14,13 +14,5 @@ _: {
       type = "http";
       url = "https://api.statsig.com/v1/mcp";
     };
-    chrome-devtools = {
-      type = "stdio";
-      command = "npx";
-      args = [
-        "-y"
-        "chrome-devtools-mcp@latest"
-      ];
-    };
   };
 }

--- a/modules/ai/tools/work.nix
+++ b/modules/ai/tools/work.nix
@@ -55,21 +55,6 @@
       };
       skills = [ "worktrunk" ];
     };
-    chrome-devtools = {
-      enable = true;
-      sources.chrome-devtools-mcp = {
-        path = sources.chrome-devtools-mcp-skills.src;
-        subdir = "skills";
-      };
-      skills = [
-        "chrome-devtools"
-        "chrome-devtools-cli"
-        "a11y-debugging"
-        "debug-optimize-lcp"
-        "memory-leak-debugging"
-        "troubleshooting"
-      ];
-    };
     agent-slack = {
       enable = true;
       sources.agent-slack = {

--- a/nvfetcher.toml
+++ b/nvfetcher.toml
@@ -128,11 +128,6 @@ src.git = "https://github.com/pproenca/dot-skills"
 src.branch = "master"
 fetch.git = "https://github.com/pproenca/dot-skills"
 
-[chrome-devtools-mcp-skills]
-src.git = "https://github.com/ChromeDevTools/chrome-devtools-mcp"
-src.branch = "main"
-fetch.git = "https://github.com/ChromeDevTools/chrome-devtools-mcp"
-
 [itechmeat-skills]
 src.git = "https://github.com/itechmeat/llm-code"
 src.branch = "master"

--- a/secrets/exa-api-key.age
+++ b/secrets/exa-api-key.age
@@ -1,7 +1,0 @@
-age-encryption.org/v1
--> ssh-ed25519 lDbMYA 1DlO/o8JHn3gF6Tz5KQE06MUx3lK5NnWDYYkCBwHJXw
-0FUzcQopTkQHwJKaHtkKiOT7levpn550EuNFkmtkwXI
--> ssh-ed25519 AX/SNw unr5ldAp0LAjw90XM7TPQDLfa9iibfzDbm12kJ7pb0o
-r4QxHThqh6/Sbkks6B9hoNwCBg0JTsz4L9uBFalPBRo
---- 7sBUCzuWp648PqN+eCuOD5k35LsU2BaI5iD2jK3i7L8
-$'}3+I—Êt%9\§®nltübòÇ~µ6)úœá:ºğ2‘˜™>aĞíáVK”;Ñ©aÌ¿Á³²Î=ÏZƒç¹

--- a/secrets/secrets.nix
+++ b/secrets/secrets.nix
@@ -9,5 +9,4 @@ in
 {
   "anthropic-api-key.age".publicKeys = [ matthewthomas ];
   "context7-api-key.age".publicKeys = all;
-  "exa-api-key.age".publicKeys = all;
 }


### PR DESCRIPTION
- Drop the chrome-devtools MCP server and its six skills (chrome-devtools, chrome-devtools-cli, a11y-debugging, debug-optimize-lcp, memory-leak-debugging, troubleshooting)
- Remove the chrome-devtools-mcp nvfetcher source; regeneration also dropped a stale omp pin left behind when omp moved to the llm-agents flake input
- Update browser instructions to stop referencing DevTools MCP