### PR TITLE
fix: stop weekly nix-gc aborting on TCC-stamped .app bundles

### DIFF
--- a/modules/darwin/system/nix.nix
+++ b/modules/darwin/system/nix.nix
@@ -18,7 +18,22 @@
   # launchd's `command` is exec-wrapped, so compound commands need a script.
   launchd.daemons.nix-gc = {
     command = "${pkgs.writeShellScript "nix-gc" ''
-      /nix/var/nix/profiles/default/bin/nix-collect-garbage --delete-older-than 30d
+      # macOS stamps `com.apple.macl` on an .app bundle once it is granted a TCC
+      # permission. That xattr makes the bundle un-chmod-able, so when the path
+      # later becomes garbage `nix-collect-garbage` aborts the ENTIRE run on it
+      # (deleting one path, freeing nothing) and every subsequent sweep dies the
+      # same way. Retry, stripping the macl off whichever path blocked us — only
+      # ever a dead path, so no live app loses its TCC grants.
+      for _ in 1 2 3 4 5; do
+        gc_out=$(/nix/var/nix/profiles/default/bin/nix-collect-garbage --delete-older-than 30d 2>&1)
+        gc_rc=$?
+        printf '%s\n' "$gc_out"
+        [ $gc_rc -eq 0 ] && break
+        gc_blocked=$(printf '%s\n' "$gc_out" | sed -n 's/.*fchmodat "\(.*\)".*/\1/p' | head -1)
+        [ -n "$gc_blocked" ] || break
+        echo "nix-gc: clearing com.apple.macl from $gc_blocked"
+        /usr/bin/xattr -d com.apple.macl "$gc_blocked" 2>/dev/null || break
+      done
       /nix/var/nix/profiles/default/bin/nix store optimise
     ''}";
     serviceConfig = {


### PR DESCRIPTION
macOS writes `com.apple.macl` onto an .app bundle once it is granted a
TCC permission. That xattr makes the bundle resist chmod, and since Nix
must chmod a store path writable before unlinking it, the deletion fails
with EPERM.

nix-collect-garbage treats that as fatal and aborts the whole run, so
every path queued behind the offender survives. On this host a dead
ghostty-bin-1.2.3 sat at the head of the queue and killed 17 consecutive
weekly sweeps -- each one reporting "1 store paths deleted, 0.0 KiB
freed" -- leaving 10550 collectable paths and five resident copies of
llvm-21.1.8-lib at ~425 MiB each.

Retry the collection, parsing the blocking path out of the fchmodat
error and stripping its macl before the next attempt. A path can only
appear in that error because Nix already classified it as garbage, so
live apps are never touched and keep their TCC grants.

Clearing the backlog by hand freed 22.6 GiB.
